### PR TITLE
feat: Google認証機能の追加

### DIFF
--- a/docs/superpowers/plans/2026-03-21-google-auth.md
+++ b/docs/superpowers/plans/2026-03-21-google-auth.md
@@ -1,0 +1,309 @@
+# Google認証機能 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Google OAuthでの新規登録・ログインを可能にし、初回ログイン時にトレーナーレコードを自動作成する
+
+**Architecture:** `/auth/callback` Route Handlerを拡張し、セッション交換後にtrainersテーブルへのupsertを行う。新規ユーザーにはダッシュボードでトースト通知を表示。トーストライブラリとしてsonnerを導入。
+
+**Tech Stack:** Next.js 15 (App Router), Supabase Auth (OAuth), supabaseAdmin, sonner (toast)
+
+**Spec:** `docs/superpowers/specs/2026-03-21-google-auth-design.md`
+
+---
+
+## ファイル構成
+
+| 操作 | ファイル | 責務 |
+|------|---------|------|
+| 修正 | `src/app/auth/callback/route.ts` | セッション交換 + trainer upsert |
+| 修正 | `src/app/(user_console)/layout.tsx` | `<Toaster />` 配置 |
+| 修正 | `src/app/(user_console)/dashboard/page.tsx` | welcome トースト表示 |
+| 新規なし | ログイン/サインアップページ | Googleボタン既存。変更不要 |
+
+---
+
+## Task 1: sonner インストール
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: sonner をインストール**
+
+```bash
+npm install sonner
+```
+
+- [ ] **Step 2: インストール確認**
+
+```bash
+npm ls sonner
+```
+
+Expected: `sonner@x.x.x` が表示される
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: sonner をインストール（トースト通知ライブラリ）"
+```
+
+---
+
+## Task 2: Toaster をレイアウトに配置
+
+**Files:**
+- Modify: `src/app/(user_console)/layout.tsx`
+
+- [ ] **Step 1: Toaster を layout.tsx に追加**
+
+`src/app/(user_console)/layout.tsx` の `Sidebar` コンポーネント内で `{children}` の隣に `<Toaster />` を配置する。
+
+```tsx
+// import 追加
+import { Toaster } from 'sonner'
+
+// return 内の </main> の直前に追加
+<Toaster
+  position="top-right"
+  toastOptions={{
+    style: {
+      fontFamily: "'Noto Sans JP', 'Plus Jakarta Sans', sans-serif",
+    },
+  }}
+/>
+```
+
+配置場所: `return` の `<main>` タグの閉じタグ直前（`{children}` を含む `<section>` の外側）。
+
+- [ ] **Step 2: ビルド確認**
+
+```bash
+npm run build
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(user_console\)/layout.tsx
+git commit -m "feat: Toaster コンポーネントを user_console レイアウトに配置"
+```
+
+---
+
+## Task 3: コールバックにトレーナー自動作成ロジックを追加
+
+**Files:**
+- Modify: `src/app/auth/callback/route.ts`
+
+- [ ] **Step 1: callback/route.ts を書き換え**
+
+以下の内容で `src/app/auth/callback/route.ts` を更新する。既存のコード交換ロジックの後に、trainer upsert を追加。
+
+```typescript
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/dashboard'
+
+  if (code) {
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll()
+          },
+          setAll(cookiesToSet) {
+            try {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                cookieStore.set(name, value, options)
+              )
+            } catch {
+              // The `setAll` method was called from a Server Component.
+            }
+          },
+        },
+      }
+    )
+
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error && data.user) {
+      const user = data.user
+
+      // トレーナーレコードの upsert（ON CONFLICT DO NOTHING）
+      let isNewUser = false
+      try {
+        const name =
+          user.user_metadata?.full_name ||
+          user.email?.split('@')[0] ||
+          'Unknown'
+        const email = user.email || ''
+        const profileImageUrl = user.user_metadata?.avatar_url || null
+
+        const { data: upsertData } = await supabaseAdmin
+          .from('trainers')
+          .upsert(
+            {
+              id: user.id,
+              name,
+              email,
+              profile_image_url: profileImageUrl,
+            },
+            { onConflict: 'id', ignoreDuplicates: true }
+          )
+          .select('created_at')
+          .maybeSingle()
+
+        // ignoreDuplicates: true の場合、既存レコードは返らない（null）
+        // データが返れば新規作成されたことを意味する
+        isNewUser = upsertData !== null
+      } catch (upsertError) {
+        console.error('トレーナーレコード作成エラー:', upsertError)
+        // セッションは有効なのでリダイレクトは続行
+      }
+
+      // リダイレクト先を構築
+      const redirectPath = isNewUser
+        ? `${next}${next.includes('?') ? '&' : '?'}welcome=true`
+        : next
+
+      const forwardedHost = request.headers.get('x-forwarded-host')
+      const isLocalEnv = process.env.NODE_ENV === 'development'
+
+      if (isLocalEnv) {
+        return NextResponse.redirect(`${origin}${redirectPath}`)
+      } else if (forwardedHost) {
+        return NextResponse.redirect(`https://${forwardedHost}${redirectPath}`)
+      } else {
+        return NextResponse.redirect(`${origin}${redirectPath}`)
+      }
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
+}
+```
+
+重要なポイント:
+- `supabaseAdmin` を import（サーバーサイドのみ。RLS バイパス）
+- `upsert` に `ignoreDuplicates: true` を使用（`ON CONFLICT DO NOTHING` 相当）
+- `.maybeSingle()` を使用（`.single()` だと既存ユーザー時に0行エラーが発生するため）
+- `ignoreDuplicates: true` の場合、既存レコードは `.select()` で返らない。`upsertData !== null` なら新規ユーザー
+- エラー時は `console.error` で記録しリダイレクト続行
+- 既存の `next` パラメータを維持
+
+- [ ] **Step 2: ビルド確認**
+
+```bash
+npm run build
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/auth/callback/route.ts
+git commit -m "feat: OAuth コールバックでトレーナーレコードを自動作成（upsert）"
+```
+
+---
+
+## Task 4: ダッシュボードにウェルカムトーストを追加
+
+**Files:**
+- Modify: `src/app/(user_console)/dashboard/page.tsx`
+
+- [ ] **Step 1: dashboard/page.tsx にトースト表示ロジックを追加**
+
+以下の変更を加える:
+
+1. import を追加:
+
+```tsx
+import { useSearchParams, useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+```
+
+2. `DashboardPage` コンポーネント内に追加（既存の `useEffect` の前）:
+
+```tsx
+const searchParams = useSearchParams()
+const router = useRouter()
+
+useEffect(() => {
+  if (searchParams.get('welcome') === 'true') {
+    toast.success('Googleアカウントの名前で登録しました。設定画面から変更できます', {
+      duration: 6000,
+    })
+    // URL からパラメータを除去
+    router.replace('/dashboard')
+  }
+}, [searchParams, router])
+```
+
+注意: `useRouter` は `next/navigation` から import。`dashboard/page.tsx` は `"use client"` なので `useSearchParams` が使える。
+
+- [ ] **Step 2: ビルド確認**
+
+```bash
+npm run build
+```
+
+Expected: エラーなし
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(user_console\)/dashboard/page.tsx
+git commit -m "feat: Google新規登録時にウェルカムトーストを表示"
+```
+
+---
+
+## Task 5: 手動設定ガイド & 動作確認
+
+- [ ] **Step 1: Google Cloud Console + Supabase の設定確認**
+
+ユーザーに以下の手動設定を依頼:
+
+1. **Google Cloud Console:**
+   - プロジェクト作成 or 既存使用
+   - OAuth 同意画面を設定（外部ユーザータイプ）
+   - OAuth 2.0 クライアントID を作成
+     - 承認済み JavaScript オリジン: `http://localhost:3000`
+     - 承認済みリダイレクト URI: `https://<supabase-project-ref>.supabase.co/auth/v1/callback`
+   - Client ID / Client Secret を控える
+
+2. **Supabase Dashboard:**
+   - Authentication → Providers → Google を有効化
+   - Client ID / Client Secret を入力して保存
+   - Authentication → Settings → User Identity Linking を確認（推奨: Automatic linking）
+
+- [ ] **Step 2: 動作確認（手動テスト）**
+
+以下のシナリオを確認:
+
+1. **新規 Google ユーザー**: ログインページ → Google ボタン → Google 認証 → ダッシュボード + ウェルカムトースト表示
+2. **既存 Google ユーザー（2回目以降）**: ログインページ → Google ボタン → ダッシュボード（トーストなし）
+3. **既存メール/パスワードユーザー**: 従来通りログインできること
+4. **サインアップページからの Google 登録**: サインアップ → Google ボタン → 同じフロー
+
+- [ ] **Step 3: Commit（もし設定変更があれば）**
+
+```bash
+git add -A
+git commit -m "docs: Google認証の設定完了"
+```

--- a/docs/superpowers/specs/2026-03-21-google-auth-design.md
+++ b/docs/superpowers/specs/2026-03-21-google-auth-design.md
@@ -1,7 +1,7 @@
 # Google認証機能 設計書
 
 **作成日**: 2026-03-21
-**ステータス**: 承認済み
+**ステータス**: 承認済み（レビュー反映済み）
 
 ---
 
@@ -23,9 +23,10 @@ FIT-CONNECTにGoogle OAuth認証を追加し、Googleアカウントのみで新
 ```
 Googleボタン → Google OAuth画面 → /auth/callback
   → supabase.auth.exchangeCodeForSession(code)
-  → supabaseAdmin で trainers テーブルを確認（user.id で検索）
-  → レコードなし → INSERT { id: user.id, name: user_metadata.full_name, email: user.email }
-  → /dashboard?welcome=true へリダイレクト
+  → supabaseAdmin で trainers テーブルに upsert（ON CONFLICT DO NOTHING）
+    { id: user.id, name: user_metadata.full_name, email: user.email, profile_image_url: user_metadata.avatar_url }
+  → upsert の結果で新規作成かどうか判定
+  → 新規: /dashboard?welcome=true へリダイレクト（nextパラメータがあればそちらを優先）
   → ダッシュボードでトースト表示:
     「Googleアカウントの名前で登録しました。設定画面から変更できます」
 ```
@@ -35,8 +36,8 @@ Googleボタン → Google OAuth画面 → /auth/callback
 ```
 Googleボタン → Google OAuth画面 → /auth/callback
   → セッション交換
-  → trainers テーブルにレコードあり → スキップ
-  → /dashboard へリダイレクト
+  → upsert → ON CONFLICT DO NOTHING（既存レコード維持）
+  → next パラメータ or /dashboard へリダイレクト
 ```
 
 ### 既存フロー（メール/パスワード）
@@ -47,20 +48,29 @@ Googleボタン → Google OAuth画面 → /auth/callback
 
 ### 1. `/src/app/auth/callback/route.ts`（主要変更）
 
-コード交換後にトレーナーレコードの存在確認・自動作成ロジックを追加。
+コード交換後にトレーナーレコードの upsert ロジックを追加。
 
 - `supabaseAdmin` を使用（RLSバイパス、既存パターン踏襲）
+- **upsert** を使用（`ON CONFLICT (id) DO NOTHING`）。select→insertのレースコンディションを防止
 - `user_metadata.full_name` が空の場合、メールアドレスの `@` 前をフォールバック名に使用
-- 新規作成時は `/dashboard?welcome=true` にリダイレクト
-- 既存ユーザーは `/dashboard` にリダイレクト
+- `user_metadata.avatar_url` を `profile_image_url` に設定
+- 新規作成時は `?welcome=true` を付与してリダイレクト
+- **既存の `next` クエリパラメータを維持**（デフォルト: `/dashboard`）
+- **エラーハンドリング**: upsert失敗時は `console.error` でログ出力し、リダイレクトは続行する（セッションは有効なため、ダッシュボードの既存の空状態表示で対応）
 
-### 2. `/src/app/(user_console)/dashboard/page.tsx`（トースト追加）
+### 2. トースト基盤の追加
+
+- **ライブラリ**: `sonner` を採用（軽量、Radix UIと相性良好、設定が最小限）
+- **Toaster配置**: `/src/app/(user_console)/layout.tsx` に `<Toaster />` を追加（user_console配下全体で利用可能に）
+- 今後の通知機能でも再利用可能
+
+### 3. `/src/app/(user_console)/dashboard/page.tsx`（トースト表示）
 
 - URLパラメータ `welcome=true` を検知
-- トースト通知で「Googleアカウントの名前で登録しました。設定画面から変更できます」を表示
+- `sonner` の `toast()` で通知表示
 - 表示後にURLからパラメータを除去（`router.replace`）
 
-### 3. UIボタン（変更なし）
+### 4. UIボタン（変更なし）
 
 ログイン・サインアップページのGoogleボタンは既に配置済み。変更不要。
 
@@ -74,6 +84,7 @@ Googleボタン → Google OAuth画面 → /auth/callback
    - アプリ名、サポートメール等を入力
 3. 「認証情報」→「認証情報を作成」→「OAuth 2.0 クライアントID」
    - アプリケーションの種類: ウェブアプリケーション
+   - 承認済みJavaScriptオリジン: `http://localhost:3000`（開発用）、本番ドメイン
    - 承認済みリダイレクトURI: `https://<supabase-project-ref>.supabase.co/auth/v1/callback`
 4. Client ID と Client Secret を控える
 
@@ -88,3 +99,4 @@ Googleボタン → Google OAuth画面 → /auth/callback
 - `supabaseAdmin`（サービスロールキー）はサーバーサイドのみで使用
 - トレーナーレコード作成はコールバック（サーバーサイド）で行うため、RLSの影響を受けない
 - 既存のメール/パスワードサインアップフローの`/api/trainers/create`ルートはそのまま維持
+- **アカウントリンク**: 同一メールで異なるプロバイダ（Google / email+password）を使用した場合の動作はSupabaseの「User Identity Linking」設定に依存する。Supabase Dashboardで自動リンクの設定を確認すること

--- a/docs/superpowers/specs/2026-03-21-google-auth-design.md
+++ b/docs/superpowers/specs/2026-03-21-google-auth-design.md
@@ -1,0 +1,90 @@
+# Google認証機能 設計書
+
+**作成日**: 2026-03-21
+**ステータス**: 承認済み
+
+---
+
+## 概要
+
+FIT-CONNECTにGoogle OAuth認証を追加し、Googleアカウントのみで新規登録・ログインを可能にする。
+
+## 要件
+
+- Googleアカウントでログイン・サインアップ両方に対応
+- 新規登録時はGoogleの表示名を自動取得（後から設定画面で変更可能）
+- 既存のメール/パスワード認証はそのまま維持
+- ログイン・サインアップ両ページのGoogleボタンは既存UIを使用（変更なし）
+
+## 認証フロー
+
+### 新規ユーザー（Google）
+
+```
+Googleボタン → Google OAuth画面 → /auth/callback
+  → supabase.auth.exchangeCodeForSession(code)
+  → supabaseAdmin で trainers テーブルを確認（user.id で検索）
+  → レコードなし → INSERT { id: user.id, name: user_metadata.full_name, email: user.email }
+  → /dashboard?welcome=true へリダイレクト
+  → ダッシュボードでトースト表示:
+    「Googleアカウントの名前で登録しました。設定画面から変更できます」
+```
+
+### 既存ユーザー（Google）
+
+```
+Googleボタン → Google OAuth画面 → /auth/callback
+  → セッション交換
+  → trainers テーブルにレコードあり → スキップ
+  → /dashboard へリダイレクト
+```
+
+### 既存フロー（メール/パスワード）
+
+変更なし。
+
+## 変更対象ファイル
+
+### 1. `/src/app/auth/callback/route.ts`（主要変更）
+
+コード交換後にトレーナーレコードの存在確認・自動作成ロジックを追加。
+
+- `supabaseAdmin` を使用（RLSバイパス、既存パターン踏襲）
+- `user_metadata.full_name` が空の場合、メールアドレスの `@` 前をフォールバック名に使用
+- 新規作成時は `/dashboard?welcome=true` にリダイレクト
+- 既存ユーザーは `/dashboard` にリダイレクト
+
+### 2. `/src/app/(user_console)/dashboard/page.tsx`（トースト追加）
+
+- URLパラメータ `welcome=true` を検知
+- トースト通知で「Googleアカウントの名前で登録しました。設定画面から変更できます」を表示
+- 表示後にURLからパラメータを除去（`router.replace`）
+
+### 3. UIボタン（変更なし）
+
+ログイン・サインアップページのGoogleボタンは既に配置済み。変更不要。
+
+## 事前設定手順（手動）
+
+### Google Cloud Console
+
+1. Google Cloud Console (https://console.cloud.google.com) でプロジェクトを作成（または既存を使用）
+2. 「APIとサービス」→「OAuth同意画面」を設定
+   - ユーザータイプ: 外部
+   - アプリ名、サポートメール等を入力
+3. 「認証情報」→「認証情報を作成」→「OAuth 2.0 クライアントID」
+   - アプリケーションの種類: ウェブアプリケーション
+   - 承認済みリダイレクトURI: `https://<supabase-project-ref>.supabase.co/auth/v1/callback`
+4. Client ID と Client Secret を控える
+
+### Supabase Dashboard
+
+1. Authentication → Providers → Google を有効化
+2. 取得した Client ID と Client Secret を入力
+3. 保存
+
+## 技術的考慮事項
+
+- `supabaseAdmin`（サービスロールキー）はサーバーサイドのみで使用
+- トレーナーレコード作成はコールバック（サーバーサイド）で行うため、RLSの影響を受けない
+- 既存のメール/パスワードサインアップフローの`/api/trainers/create`ルートはそのまま維持

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.4",
         "recharts": "^3.7.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
         "web-push": "^3.6.7",
@@ -8061,6 +8062,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.4",
     "recharts": "^3.7.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
     "web-push": "^3.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       recharts:
         specifier: ^3.7.0
         version: 3.7.0(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react-is@16.13.1)(react@19.1.0)(redux@5.0.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2767,6 +2770,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6114,6 +6123,11 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   signal-exit@4.1.0: {}
+
+  sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/(user_console)/dashboard/page.tsx
+++ b/src/app/(user_console)/dashboard/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { Suspense, useEffect, useState } from "react"
+import { useSearchParams, useRouter } from 'next/navigation'
+import { toast } from 'sonner'
 import { supabase } from '@/lib/supabase'
 import { getTrainer } from '@/lib/supabase/getTrainer'
 import { getClientCount } from '@/lib/supabase/getClientCount'
@@ -90,7 +92,7 @@ function TicketIcon() {
   )
 }
 
-export default function DashboardPage() {
+function DashboardContent() {
   const [loading, setLoading] = useState(true)
   const userName = useUserStore((state) => state.userName)
   const setUserName = useUserStore((state) => state.setUserName)
@@ -142,6 +144,19 @@ export default function DashboardPage() {
     if (hour < 18) return 'こんにちは'
     return 'こんばんは'
   }
+
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (searchParams.get('welcome') === 'true') {
+      toast.success('Googleアカウントの名前で登録しました。設定画面から変更できます', {
+        duration: 6000,
+      })
+      // URL からパラメータを除去
+      router.replace('/dashboard')
+    }
+  }, [searchParams, router])
 
   useEffect(() => {
     const fetchDashboardData = async () => {
@@ -331,5 +346,13 @@ export default function DashboardPage() {
         <QuickActions />
       </div>
     </main>
+  )
+}
+
+export default function DashboardPage() {
+  return (
+    <Suspense fallback={<DashboardSkeleton />}>
+      <DashboardContent />
+    </Suspense>
   )
 }

--- a/src/app/(user_console)/layout.tsx
+++ b/src/app/(user_console)/layout.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { getUnreadCounts } from '@/lib/supabase/getUnreadCounts';
+import { Toaster } from 'sonner';
 
 const mainMenuItems = [
     {
@@ -177,6 +178,14 @@ export default function Sidebar({ children }: { children: React.ReactNode }) {
                     {children}
                 </section>
             </div>
+            <Toaster
+                position="top-right"
+                toastOptions={{
+                    style: {
+                        fontFamily: "'Noto Sans JP', 'Plus Jakarta Sans', sans-serif",
+                    },
+                }}
+            />
         </main>
     );
 }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
         const email = user.email || ''
         const profileImageUrl = user.user_metadata?.avatar_url || null
 
-        const { data: upsertData } = await supabaseAdmin
+        const { data: upsertData, error: upsertError } = await supabaseAdmin
           .from('trainers')
           .upsert(
             {
@@ -59,6 +59,10 @@ export async function GET(request: Request) {
           )
           .select('created_at')
           .maybeSingle()
+
+        if (upsertError) {
+          console.error('トレーナーレコード作成エラー:', upsertError)
+        }
 
         // ignoreDuplicates: true の場合、既存レコードは返らない（null）
         // データが返れば新規作成されたことを意味する

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server'
-// The client you created from the server-side is needed here?
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  // if "next" is in param, use it as the redirect URL
   const next = searchParams.get('next') ?? '/dashboard'
 
   if (code) {
@@ -26,28 +25,66 @@ export async function GET(request: Request) {
               )
             } catch {
               // The `setAll` method was called from a Server Component.
-              // This can be ignored if you have middleware refreshing
-              // user sessions.
             }
           },
         },
       }
     )
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
-    if (!error) {
-      const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
+
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error && data.user) {
+      const user = data.user
+
+      // トレーナーレコードの upsert（ON CONFLICT DO NOTHING）
+      let isNewUser = false
+      try {
+        const name =
+          user.user_metadata?.full_name ||
+          user.email?.split('@')[0] ||
+          'Unknown'
+        const email = user.email || ''
+        const profileImageUrl = user.user_metadata?.avatar_url || null
+
+        const { data: upsertData } = await supabaseAdmin
+          .from('trainers')
+          .upsert(
+            {
+              id: user.id,
+              name,
+              email,
+              profile_image_url: profileImageUrl,
+            },
+            { onConflict: 'id', ignoreDuplicates: true }
+          )
+          .select('created_at')
+          .maybeSingle()
+
+        // ignoreDuplicates: true の場合、既存レコードは返らない（null）
+        // データが返れば新規作成されたことを意味する
+        isNewUser = upsertData !== null
+      } catch (upsertError) {
+        console.error('トレーナーレコード作成エラー:', upsertError)
+        // セッションは有効なのでリダイレクトは続行
+      }
+
+      // リダイレクト先を構築
+      const redirectPath = isNewUser
+        ? `${next}${next.includes('?') ? '&' : '?'}welcome=true`
+        : next
+
+      const forwardedHost = request.headers.get('x-forwarded-host')
       const isLocalEnv = process.env.NODE_ENV === 'development'
+
       if (isLocalEnv) {
-        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-        return NextResponse.redirect(`${origin}${next}`)
+        return NextResponse.redirect(`${origin}${redirectPath}`)
       } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`)
+        return NextResponse.redirect(`https://${forwardedHost}${redirectPath}`)
       } else {
-        return NextResponse.redirect(`${origin}${next}`)
+        return NextResponse.redirect(`${origin}${redirectPath}`)
       }
     }
   }
 
-  // return the user to an error page with instructions
   return NextResponse.redirect(`${origin}/auth/auth-code-error`)
 }


### PR DESCRIPTION
## Summary
- Google OAuthによるログイン・サインアップ機能を追加
- OAuthコールバックでtrainersテーブルへの自動レコード作成（upsert）
- 新規Googleユーザーにウェルカムトースト通知を表示（sonner導入）

## 変更内容
- `src/app/auth/callback/route.ts`: セッション交換後にsupabaseAdminでtrainer upsert
- `src/app/(user_console)/layout.tsx`: sonner Toasterコンポーネント配置
- `src/app/(user_console)/dashboard/page.tsx`: `?welcome=true`検知でトースト表示 + Suspense対応
- `sonner` パッケージ追加

## 事前設定（手動）
- Google Cloud Console: OAuth 2.0クライアントID設定済み
- Supabase Dashboard: Google Provider有効化済み

## Test plan
- [x] 新規Googleユーザー: ログイン → Google認証 → ダッシュボード + トースト表示
- [x] 既存Googleユーザー: ログイン → ダッシュボード（トーストなし）
- [x] メール/パスワードユーザー: 従来通りログイン可能
- [x] ビルド成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)