### PR TITLE
feat: 体重予測機能（BMR計算・カロリー収支・トレンドライン）

### DIFF
--- a/src/app/(user_console)/clients/[client_id]/_components/SummaryTab.tsx
+++ b/src/app/(user_console)/clients/[client_id]/_components/SummaryTab.tsx
@@ -5,6 +5,12 @@ import { format } from 'date-fns'
 import { WeightChart } from '@/components/clients/WeightChart'
 import type { WeightRecord, MealRecord, ExerciseRecord, Ticket } from '@/types/client'
 import { MEAL_TYPE_OPTIONS, EXERCISE_TYPE_OPTIONS, PURPOSE_OPTIONS } from '@/types/client'
+import {
+  type BmrFormula,
+  calculateBmr,
+  calculateCalorieBalance,
+  predictWeight,
+} from '@/utils/weightPrediction'
 
 interface SummaryTabProps {
   weightRecords: WeightRecord[]
@@ -16,6 +22,9 @@ interface SummaryTabProps {
   purpose?: string
   goalDescription?: string | null
   goalDeadline?: string | null
+  clientAge?: number
+  clientGender?: 'male' | 'female' | 'other'
+  bmrFormula?: BmrFormula
 }
 
 const MEAL_EMOJI: Record<string, string> = {
@@ -35,6 +44,9 @@ export function SummaryTab({
   purpose,
   goalDescription,
   goalDeadline,
+  clientAge,
+  clientGender,
+  bmrFormula = 'mifflin',
 }: SummaryTabProps) {
   // 有効チケット
   const activeTickets = useMemo(() => {
@@ -71,6 +83,42 @@ export function SummaryTab({
       .sort((a, b) => b.date.getTime() - a.date.getTime())
       .slice(0, 6)
   }, [mealRecords, exerciseRecords])
+
+  // 予測データ（30日固定）
+  const predictionData = useMemo(() => {
+    const currentWeight = weightRecords[0]?.weight ?? null
+    if (!currentWeight || !height || !clientAge || !clientGender) return null
+
+    const bmr = calculateBmr({
+      weight: currentWeight,
+      height,
+      age: clientAge,
+      gender: clientGender,
+      formula: bmrFormula,
+    })
+
+    // 直近30日の食事・運動記録をフィルタ
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    const recentMeals = mealRecords.filter((m) => new Date(m.recorded_at) >= thirtyDaysAgo)
+    const recentExercises = exerciseRecords.filter((e) => new Date(e.recorded_at) >= thirtyDaysAgo)
+
+    const balance = calculateCalorieBalance({
+      mealRecords: recentMeals,
+      exerciseRecords: recentExercises,
+      bmr,
+      periodDays: 30,
+    })
+
+    if (balance.dailyBalance === null) return { bmr, prediction: null, currentWeight }
+
+    const prediction = predictWeight({
+      currentWeight,
+      targetWeight,
+      dailyBalance: balance.dailyBalance,
+    })
+
+    return { bmr, prediction, currentWeight }
+  }, [weightRecords, height, clientAge, clientGender, bmrFormula, mealRecords, exerciseRecords, targetWeight])
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
@@ -154,6 +202,45 @@ export function SummaryTab({
               </div>
             )}
           </div>
+        </div>
+
+        {/* 体重予測カード（コンパクト） */}
+        <div className="bg-white border border-[#E2E8F0] rounded-md p-4">
+          <h3 className="text-sm font-semibold text-[#0F172A] mb-3">体重予測</h3>
+          {predictionData ? (
+            <div className="space-y-2.5">
+              <div className="flex justify-between py-1">
+                <span className="text-xs text-[#94A3B8]">基礎代謝 (BMR)</span>
+                <span className="text-sm font-medium text-[#0F172A]">
+                  {Math.round(predictionData.bmr).toLocaleString()}kcal/日
+                </span>
+              </div>
+              {predictionData.prediction && (
+                <>
+                  <div className="flex justify-between border-t border-[#F1F5F9] py-1 pt-2.5">
+                    <span className="text-xs text-[#94A3B8]">1ヶ月後予測</span>
+                    <span className={`text-sm font-bold ${predictionData.prediction.monthlyChange > 0 ? 'text-[#DC2626]' : 'text-[#16A34A]'}`}>
+                      {predictionData.prediction.predictedWeight}kg
+                      <span className="text-[10px] ml-1">
+                        ({predictionData.prediction.monthlyChange > 0 ? '+' : ''}
+                        {predictionData.prediction.monthlyChange}kg)
+                      </span>
+                    </span>
+                  </div>
+                  {predictionData.prediction.monthsToGoal !== null && (
+                    <div className="flex justify-between border-t border-[#F1F5F9] py-1 pt-2.5">
+                      <span className="text-xs text-[#94A3B8]">目標到達</span>
+                      <span className="text-sm font-bold text-[#14B8A6]">
+                        {predictionData.prediction.monthsToGoal}ヶ月
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-[#94A3B8]">クライアント情報が不足しています</p>
+          )}
         </div>
 
         {/* チケットステータス */}

--- a/src/app/(user_console)/clients/[client_id]/_components/WeightTab.tsx
+++ b/src/app/(user_console)/clients/[client_id]/_components/WeightTab.tsx
@@ -5,14 +5,27 @@ import Image from 'next/image'
 import { format } from 'date-fns'
 import { WeightChart } from '@/components/clients/WeightChart'
 import { ImageModal } from '@/components/message/ImageModal'
-import type { WeightRecord } from '@/types/client'
+import type { WeightRecord, MealRecord, ExerciseRecord } from '@/types/client'
+import {
+  type BmrFormula,
+  type WeightPeriod,
+  calculateBmr,
+  calculateCalorieBalance,
+  predictWeight,
+  getPeriodDays,
+} from '@/utils/weightPrediction'
 
 interface WeightTabProps {
   weightRecords: WeightRecord[]
   targetWeight: number
+  mealRecords: MealRecord[]
+  exerciseRecords: ExerciseRecord[]
+  clientHeight: number
+  clientAge: number
+  clientGender: 'male' | 'female' | 'other'
+  bmrFormula: BmrFormula
+  onBmrFormulaChange: (formula: BmrFormula) => void
 }
-
-type WeightPeriod = '1W' | '1M' | '3M' | 'ALL'
 
 const WEIGHT_PERIOD_BUTTONS: { value: WeightPeriod; label: string }[] = [
   { value: '1W', label: '1W' },
@@ -21,7 +34,17 @@ const WEIGHT_PERIOD_BUTTONS: { value: WeightPeriod; label: string }[] = [
   { value: 'ALL', label: 'ALL' },
 ]
 
-export function WeightTab({ weightRecords, targetWeight }: WeightTabProps) {
+export function WeightTab({
+  weightRecords,
+  targetWeight,
+  mealRecords,
+  exerciseRecords,
+  clientHeight,
+  clientAge,
+  clientGender,
+  bmrFormula,
+  onBmrFormulaChange,
+}: WeightTabProps) {
   const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null)
   const [weightPeriod, setWeightPeriod] = useState<WeightPeriod>('1M')
 
@@ -58,6 +81,62 @@ export function WeightTab({ weightRecords, targetWeight }: WeightTabProps) {
     return { avg, max, min, range }
   }, [filteredRecords])
 
+  // --- Prediction computations ---
+
+  const filteredMealRecords = useMemo(() => {
+    const days = getPeriodDays(weightPeriod)
+    const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    return mealRecords.filter((m) => new Date(m.recorded_at) >= startDate)
+  }, [mealRecords, weightPeriod])
+
+  const filteredExerciseRecords = useMemo(() => {
+    const days = getPeriodDays(weightPeriod)
+    const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    return exerciseRecords.filter((e) => new Date(e.recorded_at) >= startDate)
+  }, [exerciseRecords, weightPeriod])
+
+  const currentWeight = weightRecords[0]?.weight ?? null
+
+  const bmr = useMemo(() => {
+    if (!currentWeight || !clientHeight || !clientAge || !clientGender) return null
+    return calculateBmr({
+      weight: currentWeight,
+      height: clientHeight,
+      age: clientAge,
+      gender: clientGender,
+      formula: bmrFormula,
+    })
+  }, [currentWeight, clientHeight, clientAge, clientGender, bmrFormula])
+
+  const calorieBalance = useMemo(() => {
+    if (bmr === null) return null
+    const periodDays = getPeriodDays(weightPeriod)
+    return calculateCalorieBalance({
+      mealRecords: filteredMealRecords,
+      exerciseRecords: filteredExerciseRecords,
+      bmr,
+      periodDays,
+    })
+  }, [bmr, filteredMealRecords, filteredExerciseRecords, weightPeriod])
+
+  const prediction = useMemo(() => {
+    if (currentWeight === null || calorieBalance === null || calorieBalance.dailyBalance === null) return null
+    return predictWeight({
+      currentWeight,
+      targetWeight,
+      dailyBalance: calorieBalance.dailyBalance,
+    })
+  }, [currentWeight, targetWeight, calorieBalance])
+
+  const predictionChartData = useMemo(() => {
+    if (!prediction) return undefined
+    return {
+      monthlyChange: prediction.monthlyChange,
+      predictedWeight: prediction.predictedWeight,
+      periodDays: getPeriodDays(weightPeriod),
+    }
+  }, [prediction, weightPeriod])
+
   if (weightRecords.length === 0) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -89,13 +168,26 @@ export function WeightTab({ weightRecords, targetWeight }: WeightTabProps) {
           </div>
         </div>
 
-        {/* 目標体重インジケーター */}
-        <div className="flex items-center gap-2 mb-2 text-xs text-[#94A3B8]">
-          <span className="inline-block w-4 border-t-2 border-dashed border-[#DC2626]" />
-          <span>目標: {targetWeight}kg</span>
+        {/* 凡例 */}
+        <div className="flex items-center gap-4 mb-2 text-xs text-[#94A3B8]">
+          <div className="flex items-center gap-2">
+            <span className="inline-block w-4 border-t-2 border-dashed border-[#DC2626]" />
+            <span>目標: {targetWeight}kg</span>
+          </div>
+          {prediction && (
+            <div className="flex items-center gap-2">
+              <span className="inline-block w-4 border-t-2 border-dashed border-[#14B8A6]" />
+              <span>予測トレンド</span>
+            </div>
+          )}
         </div>
 
-        <WeightChart weightRecords={filteredRecords} targetWeight={targetWeight} showPeriodFilter={false} />
+        <WeightChart
+          weightRecords={filteredRecords}
+          targetWeight={targetWeight}
+          showPeriodFilter={false}
+          prediction={predictionChartData}
+        />
       </div>
 
       {/* 期間統計 */}
@@ -127,6 +219,103 @@ export function WeightTab({ weightRecords, targetWeight }: WeightTabProps) {
             </p>
           </div>
         </div>
+      </div>
+
+      {/* 体重予測カード */}
+      <div className="bg-white border border-[#E2E8F0] rounded-md p-4">
+        <h3 className="text-sm font-semibold text-[#0F172A] mb-3">体重予測</h3>
+
+        {/* BMR セクション */}
+        {bmr !== null ? (
+          <div className="space-y-4">
+            <div className="bg-[#F8FAFC] border border-[#E2E8F0] rounded-md p-3">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-xs text-[#94A3B8]">基礎代謝量 (BMR)</p>
+                <select
+                  value={bmrFormula}
+                  onChange={(e) => onBmrFormulaChange(e.target.value as BmrFormula)}
+                  className="text-xs text-[#64748B] bg-white border border-[#E2E8F0] rounded-md px-2 py-1"
+                >
+                  <option value="mifflin">ミフリン・セントジョール式</option>
+                  <option value="harris">ハリス・ベネディクト式</option>
+                </select>
+              </div>
+              <p className="text-xl font-bold text-[#0F172A]">
+                {Math.round(bmr)}
+                <span className="text-xs text-[#94A3B8] ml-1">kcal/日</span>
+              </p>
+            </div>
+
+            {/* カロリー収支 */}
+            {calorieBalance && calorieBalance.dailyBalance !== null && (
+              <div className="grid grid-cols-3 gap-3">
+                <div className="bg-[#FFF7ED] border border-[#E2E8F0] rounded-md p-3">
+                  <p className="text-xs text-[#EA580C] mb-1">平均摂取</p>
+                  <p className="text-lg font-bold text-[#EA580C]">
+                    {calorieBalance.avgIntake !== null ? calorieBalance.avgIntake.toLocaleString() : '--'}
+                    <span className="text-[10px] ml-0.5">kcal</span>
+                  </p>
+                </div>
+                <div className="bg-[#F0FDF4] border border-[#E2E8F0] rounded-md p-3">
+                  <p className="text-xs text-[#16A34A] mb-1">平均消費</p>
+                  <p className="text-lg font-bold text-[#16A34A]">
+                    {calorieBalance.avgExerciseBurn !== null
+                      ? (calorieBalance.avgExerciseBurn + Math.round(bmr)).toLocaleString()
+                      : Math.round(bmr).toLocaleString()}
+                    <span className="text-[10px] ml-0.5">kcal</span>
+                  </p>
+                </div>
+                <div className="bg-[#F8FAFC] border border-[#E2E8F0] rounded-md p-3">
+                  <p className="text-xs text-[#94A3B8] mb-1">1日の収支</p>
+                  <p className={`text-lg font-bold ${calorieBalance.dailyBalance > 0 ? 'text-[#DC2626]' : 'text-[#16A34A]'}`}>
+                    {calorieBalance.dailyBalance > 0 ? '+' : ''}
+                    {calorieBalance.dailyBalance.toLocaleString()}
+                    <span className="text-[10px] ml-0.5">kcal</span>
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* 予測結果 */}
+            {prediction && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-white border border-[#E2E8F0] rounded-md p-3">
+                  <p className="text-xs text-[#94A3B8] mb-1">1ヶ月後予測</p>
+                  <p className={`text-xl font-bold ${prediction.monthlyChange > 0 ? 'text-[#DC2626]' : 'text-[#16A34A]'}`}>
+                    {prediction.predictedWeight}
+                    <span className="text-xs ml-1">kg</span>
+                  </p>
+                  <p className={`text-xs mt-0.5 ${prediction.monthlyChange > 0 ? 'text-[#DC2626]' : 'text-[#16A34A]'}`}>
+                    {prediction.monthlyChange > 0 ? '+' : ''}
+                    {prediction.monthlyChange}kg/月
+                  </p>
+                </div>
+                <div className="bg-white border border-[#E2E8F0] rounded-md p-3">
+                  <p className="text-xs text-[#94A3B8] mb-1">目標到達</p>
+                  {prediction.monthsToGoal !== null ? (
+                    <p className="text-xl font-bold text-[#14B8A6]">
+                      {prediction.monthsToGoal}
+                      <span className="text-xs ml-1">ヶ月</span>
+                    </p>
+                  ) : (
+                    <p className="text-sm text-[#94A3B8]">
+                      現在のペースでは<br />目標に近づいていません
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* データ不足時メッセージ */}
+            {calorieBalance === null || calorieBalance.dailyBalance === null ? (
+              <p className="text-xs text-[#94A3B8]">
+                食事・運動記録が不足しています。記録を追加すると予測が表示されます。
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm text-[#94A3B8]">クライアント情報が不足しています</p>
+        )}
       </div>
 
       {/* 最近の記録リスト（最新5件） */}

--- a/src/app/(user_console)/clients/[client_id]/page.tsx
+++ b/src/app/(user_console)/clients/[client_id]/page.tsx
@@ -13,6 +13,7 @@ import { getClientAssignments } from '@/lib/supabase/getClientAssignments'
 import { supabase } from '@/lib/supabase'
 import type { ClientDetail, WeightRecord, MealRecord, ExerciseRecord, Ticket, ClientNote } from '@/types/client'
 import type { WorkoutAssignment } from '@/types/workout'
+import type { BmrFormula } from '@/utils/weightPrediction'
 import { ClientHeader } from './_components/ClientHeader'
 import { SummaryTab } from './_components/SummaryTab'
 import { MealTab } from './_components/MealTab'
@@ -52,6 +53,7 @@ export default function ClientDetailPage() {
   const [trainerId, setTrainerId] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [mode, setMode] = useState<'info' | 'session'>('info')
+  const [bmrFormula, setBmrFormula] = useState<BmrFormula>('mifflin')
   const [prevMode, setPrevMode] = useState<'info' | 'session'>('info')
 
   useEffect(() => {
@@ -275,6 +277,9 @@ export default function ClientDetailPage() {
                 purpose={client.purpose}
                 goalDescription={client.goal_description}
                 goalDeadline={client.goal_deadline}
+                clientAge={client.age}
+                clientGender={client.gender}
+                bmrFormula={bmrFormula}
               />
             </TabsContent>
 
@@ -286,6 +291,13 @@ export default function ClientDetailPage() {
               <WeightTab
                 weightRecords={weightRecords}
                 targetWeight={client.target_weight || 0}
+                mealRecords={mealRecords}
+                exerciseRecords={exerciseRecords}
+                clientHeight={client.height}
+                clientAge={client.age}
+                clientGender={client.gender}
+                bmrFormula={bmrFormula}
+                onBmrFormulaChange={setBmrFormula}
               />
             </TabsContent>
 

--- a/src/components/clients/WeightChart.tsx
+++ b/src/components/clients/WeightChart.tsx
@@ -4,8 +4,9 @@ import { useMemo, useState } from 'react'
 import { format, subMonths, startOfWeek, startOfMonth } from 'date-fns'
 import {
   ResponsiveContainer,
-  LineChart,
+  ComposedChart,
   Line,
+  Area,
   CartesianGrid,
   XAxis,
   YAxis,
@@ -18,11 +19,16 @@ interface WeightChartProps {
   weightRecords: WeightRecord[]
   targetWeight: number
   showPeriodFilter?: boolean
+  prediction?: {
+    monthlyChange: number
+    predictedWeight: number
+    periodDays: number
+  }
 }
 
 type PeriodFilter = 'week' | 'month' | '3months' | 'all'
 
-export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = true }: WeightChartProps) {
+export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = true, prediction }: WeightChartProps) {
   const [periodFilter, setPeriodFilter] = useState<PeriodFilter>('all')
 
   // フィルター後のデータを計算
@@ -67,6 +73,60 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
       }))
   }, [weightRecords, periodFilter, showPeriodFilter])
 
+  // 予測データを生成
+  const predictionData = useMemo(() => {
+    if (!prediction || filteredData.length === 0) return []
+
+    const lastPoint = filteredData[filteredData.length - 1]
+    const lastWeight = lastPoint.weight
+    const lastDate = lastPoint.date.getTime()
+    const dailyChange = prediction.monthlyChange / 30
+
+    // 7つの未来データポイントを生成
+    const points = []
+    const totalFutureDays = Math.min(prediction.periodDays, 90)
+    const interval = Math.max(Math.floor(totalFutureDays / 6), 1)
+
+    for (let i = 0; i <= 6; i++) {
+      const daysAhead = i === 0 ? 0 : Math.min(i * interval, totalFutureDays)
+      const futureDate = new Date(lastDate + daysAhead * 24 * 60 * 60 * 1000)
+      const futureWeight = Math.round((lastWeight + dailyChange * daysAhead) * 10) / 10
+
+      points.push({
+        date: futureDate,
+        predictionWeight: futureWeight,
+      })
+    }
+
+    return points
+  }, [prediction, filteredData])
+
+  // 実データと予測データをマージ
+  const chartData = useMemo(() => {
+    if (predictionData.length === 0) return filteredData
+
+    // 実データ
+    const actual = filteredData.map((d) => ({
+      date: d.date,
+      weight: d.weight,
+      predictionWeight: undefined as number | undefined,
+    }))
+
+    // 最後の実データポイントに予測の開始点を追加
+    if (actual.length > 0) {
+      actual[actual.length - 1].predictionWeight = actual[actual.length - 1].weight
+    }
+
+    // 予測データ（最初のポイントは実データと重複するのでスキップ）
+    const future = predictionData.slice(1).map((d) => ({
+      date: d.date,
+      weight: undefined as number | undefined,
+      predictionWeight: d.predictionWeight,
+    }))
+
+    return [...actual, ...future]
+  }, [filteredData, predictionData])
+
   // Y軸のドメインを計算
   const yAxisDomain = useMemo(() => {
     if (filteredData.length === 0) return [0, 100]
@@ -78,6 +138,20 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
     return [Math.floor(dataMin - 2), Math.ceil(dataMax + 2)]
   }, [filteredData])
 
+  // 予測を含むY軸ドメイン
+  const adjustedYDomain = useMemo(() => {
+    if (predictionData.length === 0) return yAxisDomain
+
+    const allWeights = [
+      ...filteredData.map((d) => d.weight),
+      ...predictionData.map((d) => d.predictionWeight),
+    ]
+    const dataMin = Math.min(...allWeights)
+    const dataMax = Math.max(...allWeights)
+
+    return [Math.floor(dataMin - 2), Math.ceil(dataMax + 2)]
+  }, [filteredData, predictionData, yAxisDomain])
+
   // 期間フィルターボタン
   const periodButtons: { label: string; value: PeriodFilter }[] = [
     { label: '今週', value: 'week' },
@@ -85,6 +159,8 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
     { label: '3ヶ月', value: '3months' },
     { label: '全期間', value: 'all' },
   ]
+
+  const activeDomain = prediction ? adjustedYDomain : yAxisDomain
 
   return (
     <div className="space-y-4">
@@ -116,7 +192,7 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
         </div>
       ) : (
         <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={filteredData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+          <ComposedChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
             <XAxis
               dataKey="date"
@@ -125,14 +201,21 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
               style={{ fontSize: '12px' }}
             />
             <YAxis
-              domain={yAxisDomain}
+              domain={activeDomain}
               stroke="#9ca3af"
               style={{ fontSize: '12px' }}
               label={{ value: '体重 (kg)', angle: -90, position: 'insideLeft', style: { fontSize: '12px' } }}
             />
             <Tooltip
-              labelFormatter={(label) => format(label as Date, 'yyyy年M月d日')}
-              formatter={(value) => [`${value} kg`, '体重']}
+              labelFormatter={(label) => {
+                if (label instanceof Date) return format(label, 'yyyy年M月d日')
+                return String(label)
+              }}
+              formatter={(value, name) => {
+                if (value === undefined || value === null) return ['-', '']
+                if (name === 'predictionWeight') return [`${value} kg`, '予測']
+                return [`${value} kg`, '体重']
+              }}
               contentStyle={{
                 backgroundColor: 'white',
                 border: '1px solid #e5e7eb',
@@ -148,6 +231,30 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
                 label={{ value: '目標', position: 'insideTopRight', fill: '#ef4444', fontSize: 12 }}
               />
             )}
+            {/* 予測エリア（塗り） */}
+            {prediction && (
+              <Area
+                type="monotone"
+                dataKey="predictionWeight"
+                fill="#14B8A6"
+                fillOpacity={0.1}
+                stroke="none"
+                connectNulls={false}
+              />
+            )}
+            {/* 予測ライン（破線） */}
+            {prediction && (
+              <Line
+                type="monotone"
+                dataKey="predictionWeight"
+                stroke="#14B8A6"
+                strokeWidth={2}
+                strokeDasharray="6 4"
+                dot={false}
+                connectNulls={false}
+              />
+            )}
+            {/* 実データライン */}
             <Line
               type="monotone"
               dataKey="weight"
@@ -155,8 +262,9 @@ export function WeightChart({ weightRecords, targetWeight, showPeriodFilter = tr
               strokeWidth={2}
               dot={{ fill: '#3b82f6', r: 4 }}
               activeDot={{ r: 6 }}
+              connectNulls={false}
             />
-          </LineChart>
+          </ComposedChart>
         </ResponsiveContainer>
       )}
     </div>

--- a/src/utils/weightPrediction.ts
+++ b/src/utils/weightPrediction.ts
@@ -1,0 +1,124 @@
+export type BmrFormula = 'mifflin' | 'harris'
+export type Gender = 'male' | 'female' | 'other'
+
+/**
+ * BMR（基礎代謝量）を計算する
+ */
+export function calculateBmr(params: {
+  weight: number
+  height: number
+  age: number
+  gender: Gender
+  formula: BmrFormula
+}): number {
+  const { weight, height, age, gender, formula } = params
+
+  const calcForGender = (g: 'male' | 'female'): number => {
+    if (formula === 'mifflin') {
+      // ミフリン・セントジョール式
+      return g === 'male'
+        ? 10 * weight + 6.25 * height - 5 * age + 5
+        : 10 * weight + 6.25 * height - 5 * age - 161
+    }
+    // ハリス・ベネディクト式（改良版）
+    return g === 'male'
+      ? 13.397 * weight + 4.799 * height - 5.677 * age + 88.362
+      : 9.247 * weight + 3.098 * height - 4.33 * age + 447.593
+  }
+
+  if (gender === 'other') {
+    return (calcForGender('male') + calcForGender('female')) / 2
+  }
+  return calcForGender(gender)
+}
+
+export type CalorieBalance = {
+  avgIntake: number | null
+  avgExerciseBurn: number | null
+  dailyBalance: number | null
+}
+
+/**
+ * 期間内のカロリー収支を算出する
+ */
+export function calculateCalorieBalance(params: {
+  mealRecords: { calories: number | null }[]
+  exerciseRecords: { calories: number | null }[]
+  bmr: number
+  periodDays: number
+}): CalorieBalance {
+  const { mealRecords, exerciseRecords, bmr, periodDays } = params
+
+  if (periodDays <= 0) {
+    return { avgIntake: null, avgExerciseBurn: null, dailyBalance: null }
+  }
+
+  // calories が null でない記録のみ集計
+  const validMeals = mealRecords.filter((m) => m.calories !== null)
+  const validExercises = exerciseRecords.filter((e) => e.calories !== null)
+
+  const totalIntake = validMeals.reduce((sum, m) => sum + (m.calories ?? 0), 0)
+  const totalBurn = validExercises.reduce((sum, e) => sum + (e.calories ?? 0), 0)
+
+  const avgIntake = validMeals.length > 0 ? Math.round(totalIntake / periodDays) : null
+  const avgExerciseBurn = validExercises.length > 0 ? Math.round(totalBurn / periodDays) : null
+
+  const dailyBalance = avgIntake !== null ? avgIntake - (bmr + (avgExerciseBurn ?? 0)) : null
+
+  return { avgIntake, avgExerciseBurn, dailyBalance }
+}
+
+export type WeightPrediction = {
+  monthlyChange: number
+  predictedWeight: number
+  monthsToGoal: number | null
+}
+
+const KCAL_PER_KG_FAT = 7200
+
+/**
+ * カロリー収支から体重変動を予測する
+ */
+export function predictWeight(params: {
+  currentWeight: number
+  targetWeight: number
+  dailyBalance: number
+}): WeightPrediction {
+  const { currentWeight, targetWeight, dailyBalance } = params
+
+  const monthlyChange = (dailyBalance * 30) / KCAL_PER_KG_FAT
+  const predictedWeight = currentWeight + monthlyChange
+
+  // 目標到達予測
+  const weightDiff = currentWeight - targetWeight
+  let monthsToGoal: number | null = null
+
+  if (Math.abs(monthlyChange) > 0.01) {
+    const isMovingTowardGoal =
+      (weightDiff > 0 && monthlyChange < 0) || (weightDiff < 0 && monthlyChange > 0)
+
+    if (isMovingTowardGoal) {
+      monthsToGoal = Math.round((Math.abs(weightDiff) / Math.abs(monthlyChange)) * 10) / 10
+    }
+  }
+
+  return {
+    monthlyChange: Math.round(monthlyChange * 10) / 10,
+    predictedWeight: Math.round(predictedWeight * 10) / 10,
+    monthsToGoal,
+  }
+}
+
+export type WeightPeriod = '1W' | '1M' | '3M' | 'ALL'
+
+/**
+ * 期間フィルターに対応する日数を返す
+ */
+export function getPeriodDays(period: WeightPeriod): number {
+  switch (period) {
+    case '1W': return 7
+    case '1M': return 30
+    case '3M': return 90
+    case 'ALL': return 30 // ALLのデフォルトは30日で計算
+  }
+}


### PR DESCRIPTION
## Summary
- クライアント詳細ページに体重予測機能を追加
- BMR（基礎代謝）をミフリン・セントジョール式 / ハリス・ベネディクト式で計算（プルダウン切替）
- 食事・運動記録からカロリー収支を算出し、1ヶ月後の体重変動を予測表示
- WeightTabにフルバージョン（BMR + カロリー収支 + 予測 + グラフ内トレンドライン）
- SummaryTabにコンパクト版（BMR + 予測ハイライト）
- データ不足時は段階的に表示（BMR常時 → カロリー収支はデータあり時 → 予測もデータあり時）

## Changed Files
- `src/utils/weightPrediction.ts` — 計算ロジック（BMR/カロリー収支/体重予測）
- `src/app/(user_console)/clients/[client_id]/page.tsx` — props追加・BMR formula state管理
- `src/app/(user_console)/clients/[client_id]/_components/WeightTab.tsx` — 予測カードUI
- `src/app/(user_console)/clients/[client_id]/_components/SummaryTab.tsx` — コンパクト予測カード
- `src/components/clients/WeightChart.tsx` — 予測トレンドライン描画

## Test plan
- [ ] WeightTabで体重予測カードが表示されること
- [ ] BMR計算方式をプルダウンで切り替えられること
- [ ] カロリーデータがあればカロリー収支・予測結果が表示されること
- [ ] グラフに予測トレンドライン（破線+薄塗り）が表示されること
- [ ] 期間フィルター切り替えで予測値が更新されること
- [ ] SummaryTab右カラムにコンパクト予測カードが表示されること
- [ ] データ不足時は段階的に表示が制限されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)