### PR TITLE
next.config.ts に lh3.googleusercontent.comの追加

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const nextConfig: NextConfig = {
         hostname: "viribpvnpgtgtmeulcmx.supabase.co",
         pathname: "/storage/**",
       },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
プロフィール画像がgoogleから保存したURLを取得しようとするとエラーになるバグ修正