### PR TITLE
Implement background health sync with error handling and UI feedback

### DIFF
--- a/docs/tasks/IMPLEMENTATION_TASKS.md
+++ b/docs/tasks/IMPLEMENTATION_TASKS.md
@@ -1,9 +1,9 @@
 # FIT-CONNECT - 新機能タスク一覧
 
 **作成日**: 2026年3月29日
-**バージョン**: 1.2
-**進捗状況**: 全体 18%（1.3 睡眠データ連携 完了）
-**最終更新**: 2026年4月26日 - モノレポ移行完了
+**バージョン**: 1.3
+**進捗状況**: 全体 22%（1.3 睡眠データ連携・1.4 バックグラウンド同期 完了）
+**最終更新**: 2026年4月26日 - 1.4 バックグラウンド同期 完了
 
 > **2026-04-26 モノレポ化完了**: 旧 `fit-connect-mobile` リポジトリを `git subtree` で取り込み、単一 git リポジトリで Web/Mobile 両方を管理する構成に移行。詳細は `docs/tasks/2026-04-26-monorepo-migration.md`。
 
@@ -22,7 +22,7 @@
 
 | フェーズ | 機能 | 対象 | 進捗 | 状態 |
 |---------|------|------|------|------|
-| 1 | ヘルスケア連携（体重・睡眠） | Mobile | 75% | 🟡 体重・睡眠連携完了、バックグラウンド同期未着手 |
+| 1 | ヘルスケア連携（体重・睡眠） | Mobile | 90% | 🟡 体重・睡眠・バックグラウンド同期完了、トレーナー可視化のみ未着手 |
 | 2 | オンボーディングフロー | Mobile | 0% | 🔴 未着手 |
 | 3 | ランディングページ | Web | 0% | 🔴 未着手 |
 | 4 | LLM カロリー計算 | Mobile + Supabase | 0% | 🔴 未着手 |
@@ -58,10 +58,12 @@
   - [x] 設定画面に睡眠トグル + 朝ダイアログトグル追加
   - 注: ローカル/リモートの Supabase に migration `20260422000000_create_sleep_records.sql` の適用が必要
 
-- [ ] **1.4 バックグラウンド同期**
-  - [ ] バックグラウンドでの定期同期設定
-  - [ ] 同期状態の表示（最終同期日時）
-  - [ ] エラー時のリトライ・通知
+- [x] **1.4 バックグラウンド同期** （2026-04-26 完了）
+  - [x] バックグラウンドでの定期同期設定（フォアグラウンド時 `Timer.periodic` 1時間 + アプリ resume 時に lastSync が1時間超で再同期、`lib/app.dart`）
+  - [x] 同期状態の表示（相対時間 + status アイコン + エラー詳細行、`HealthSettingsState` に `lastSyncStatus` `lastSyncError` 追加、SharedPreferences 永続化）
+  - [x] エラー時のリトライ・通知（`_runWithRetry` 指数バックオフ最大3回 1s/2s、永続失敗時に `NotificationService.showSyncErrorNotification` 通知 ID=9001）
+  - 注: `workmanager` は採用せず（iOS 制約と native 設定の複雑さを考慮）。フォアグラウンド/resume ベースで日常利用に十分な頻度を確保
+  - 注: build_runner / flutter analyze はサンドボックスで未実行のため、ローカル環境で `dart run build_runner build --delete-conflicting-outputs` の実行を推奨
 
 - [ ] **1.5 睡眠データのトレーナー可視化（Web）**
   - [ ] Web側の型定義追加（`fit-connect/src/types/`）

--- a/docs/tasks/lessons.md
+++ b/docs/tasks/lessons.md
@@ -38,3 +38,15 @@
 - **意図せず混入したもの** (.gitignore 追加候補): `.superpowers/brainstorm/*/.server.pid` 系、`.claude/skills/*/scripts/__pycache__/*.pyc`
 - **移行詳細手順書**: `docs/tasks/2026-04-26-monorepo-migration.md`
 - **未完のフォローアップ**: `docs/tasks/2026-04-26-monorepo-migration-followups.md`
+
+## バックグラウンド同期の戦略選定（タスク 1.4）
+
+- **`workmanager` を見送った理由**:
+  - iOS の `BGAppRefreshTask` / `BGProcessingTask` は OS が裁量で実行するため、最短でも数時間に1回・最悪は数日に1回しか起動しない（ヘルスケアの即時性とミスマッチ）
+  - 両プラットフォーム共通の native 設定（`AppDelegate.swift` 修正、`MainActivity.kt` 修正、トップレベル callback の dispatch 制約）が必要で、リグレッション影響範囲が大きい
+  - 体重・睡眠は1日1回〜数回程度しか変動しないため、フォアグラウンド復帰時の同期で十分鮮度を保てる
+- **採用した戦略**: `Timer.periodic(60min)` + アプリ resume 時 `lastSyncAt > 1h` で再同期。両者とも `_AuthLoadingScreenState` に集約 (`lib/app.dart`)
+- **冪等性の確保**: `_isResumeSyncing` フラグで resume 経路の二重起動を防止。`_sync()` 自体は SharedPreferences の status (idle/syncing/success/error) で進行中を可視化するが、Riverpod レベルの mutex は省略（同期内部処理は body の異常系 try/catch で完結する設計）
+- **リトライポリシー**: `_runWithRetry()` で `_syncWeight` / `_syncSleep` 各々独立に最大3回（初回 + 2リトライ、1s/2s 指数バックオフ）。体重と睡眠の片方失敗でも他方は完了させ、`lastSyncAt` は両方成功時のみ更新
+- **エラー通知**: `flutter_local_notifications` で固定 ID=9001（連続失敗時に通知トレイが膨張しない）、メッセージは120字で省略
+- **iOS/Android 以外（macOS/Web）のガード**: `health_sync_provider` 側で `kIsWeb || (!iOS && !android)` を判定し `showSyncErrorNotification` をスキップ。サービス内部の二重ガードは省略

--- a/fit-connect-mobile/lib/app.dart
+++ b/fit-connect-mobile/lib/app.dart
@@ -114,10 +114,8 @@ class _AuthLoadingScreenState extends ConsumerState<_AuthLoadingScreen>
     final settings = ref.read(healthSettingsProvider).valueOrNull;
     if (settings == null || !settings.isEnabled) return;
     final last = settings.lastSyncAt;
-    // resume 時は 5分以上経過していれば再同期（HealthKit に新しいデータが追加された
-    // 可能性が高いため、長すぎるしきい値はユーザー体験を損なう）
     if (last != null &&
-        DateTime.now().difference(last) < const Duration(minutes: 5)) {
+        DateTime.now().difference(last) < const Duration(hours: 1)) {
       return; // まだ十分新しい
     }
     _isResumeSyncing = true;

--- a/fit-connect-mobile/lib/app.dart
+++ b/fit-connect-mobile/lib/app.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,6 +14,7 @@ import 'package:fit_connect_mobile/features/auth/providers/current_user_provider
 import 'package:fit_connect_mobile/features/auth/providers/registration_provider.dart';
 import 'package:fit_connect_mobile/services/notification_service.dart';
 import 'package:fit_connect_mobile/features/health/providers/health_sync_provider.dart';
+import 'package:fit_connect_mobile/features/health/providers/health_provider.dart';
 import 'package:fit_connect_mobile/features/sleep_records/providers/morning_dialog_provider.dart';
 import 'package:fit_connect_mobile/features/sleep_records/presentation/widgets/morning_wakeup_dialog.dart';
 
@@ -76,15 +78,23 @@ class _AuthLoadingScreenState extends ConsumerState<_AuthLoadingScreen>
   bool _tokenSaved = false;
   bool _healthSynced = false;
   bool _isMorningDialogOpen = false;
+  Timer? _periodicSyncTimer;
+  bool _isResumeSyncing = false;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // 1時間ごとの定期同期（フォアグラウンド時のみ動作）
+    _periodicSyncTimer = Timer.periodic(
+      const Duration(minutes: 60),
+      (_) => _runPeriodicSync(),
+    );
   }
 
   @override
   void dispose() {
+    _periodicSyncTimer?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -95,6 +105,39 @@ class _AuthLoadingScreenState extends ConsumerState<_AuthLoadingScreen>
       // resumed 時はSleep同期完了を待たずに即時再判定（同期は別途バックグラウンド継続）
       ref.invalidate(morningDialogProvider);
       _maybeShowMorningDialog();
+      _maybeRunResumeSync();
+    }
+  }
+
+  Future<void> _maybeRunResumeSync() async {
+    if (_isResumeSyncing || !mounted) return;
+    final settings = ref.read(healthSettingsProvider).valueOrNull;
+    if (settings == null || !settings.isEnabled) return;
+    final last = settings.lastSyncAt;
+    if (last != null &&
+        DateTime.now().difference(last) < const Duration(hours: 1)) {
+      return; // まだ十分新しい
+    }
+    _isResumeSyncing = true;
+    try {
+      await ref.read(healthSyncProvider.notifier).syncOnLaunch();
+      debugPrint('[App] Resume後の同期完了');
+    } catch (e) {
+      debugPrint('[App] Resume後の同期エラー: $e');
+    } finally {
+      _isResumeSyncing = false;
+    }
+  }
+
+  Future<void> _runPeriodicSync() async {
+    if (!mounted) return;
+    final settings = ref.read(healthSettingsProvider).valueOrNull;
+    if (settings == null || !settings.isEnabled) return;
+    try {
+      await ref.read(healthSyncProvider.notifier).syncOnLaunch();
+      debugPrint('[App] 定期同期完了');
+    } catch (e) {
+      debugPrint('[App] 定期同期エラー: $e');
     }
   }
 

--- a/fit-connect-mobile/lib/app.dart
+++ b/fit-connect-mobile/lib/app.dart
@@ -114,8 +114,10 @@ class _AuthLoadingScreenState extends ConsumerState<_AuthLoadingScreen>
     final settings = ref.read(healthSettingsProvider).valueOrNull;
     if (settings == null || !settings.isEnabled) return;
     final last = settings.lastSyncAt;
+    // resume 時は 5分以上経過していれば再同期（HealthKit に新しいデータが追加された
+    // 可能性が高いため、長すぎるしきい値はユーザー体験を損なう）
     if (last != null &&
-        DateTime.now().difference(last) < const Duration(hours: 1)) {
+        DateTime.now().difference(last) < const Duration(minutes: 5)) {
       return; // まだ十分新しい
     }
     _isResumeSyncing = true;

--- a/fit-connect-mobile/lib/features/health/presentation/screens/health_settings_screen.dart
+++ b/fit-connect-mobile/lib/features/health/presentation/screens/health_settings_screen.dart
@@ -386,6 +386,9 @@ class HealthSettingsScreen extends ConsumerWidget {
     AppColorsExtension colors,
   ) {
     final isSyncing = syncAsync.isLoading;
+    final hasError = settings.lastSyncStatus == HealthSyncStatus.error;
+    final isStatusSyncing =
+        settings.lastSyncStatus == HealthSyncStatus.syncing;
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
@@ -399,7 +402,7 @@ class HealthSettingsScreen extends ConsumerWidget {
         children: [
           // Section Header
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
             child: Text(
               '同期',
               style: TextStyle(
@@ -408,6 +411,15 @@ class HealthSettingsScreen extends ConsumerWidget {
                 color: colors.textSecondary,
                 letterSpacing: 0.5,
               ),
+            ),
+          ),
+
+          // Periodic sync description
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              'アプリ起動時と1時間ごとに自動同期します',
+              style: TextStyle(fontSize: 12, color: colors.textHint),
             ),
           ),
 
@@ -422,14 +434,17 @@ class HealthSettingsScreen extends ConsumerWidget {
                 color: colors.textPrimary,
               ),
             ),
-            trailing: Text(
-              _formatLastSync(settings.lastSyncAt),
-              style: TextStyle(
-                fontSize: 14,
-                color: colors.textSecondary,
-              ),
+            trailing: _buildSyncStatusTrailing(
+              settings: settings,
+              colors: colors,
+              hasError: hasError,
+              isStatusSyncing: isStatusSyncing,
             ),
           ),
+
+          // Error detail row (only on error)
+          if (hasError && settings.lastSyncError != null)
+            _buildSyncErrorRow(settings.lastSyncError!, colors),
 
           // Manual sync button
           Padding(
@@ -442,14 +457,23 @@ class HealthSettingsScreen extends ConsumerWidget {
                         await ref
                             .read(healthSyncProvider.notifier)
                             .syncManual();
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('同期が完了しました'),
-                              backgroundColor: AppColors.emerald600,
+                        if (!context.mounted) return;
+                        final result =
+                            ref.read(healthSettingsProvider).valueOrNull;
+                        final isError = result?.lastSyncStatus ==
+                            HealthSyncStatus.error;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              isError
+                                  ? '同期に失敗しました: ${result?.lastSyncError ?? "原因不明"}'
+                                  : '同期が完了しました',
                             ),
-                          );
-                        }
+                            backgroundColor: isError
+                                ? AppColors.error
+                                : AppColors.emerald600,
+                          ),
+                        );
                       }
                     : null,
                 icon: isSyncing
@@ -479,13 +503,101 @@ class HealthSettingsScreen extends ConsumerWidget {
     );
   }
 
+  Widget _buildSyncStatusTrailing({
+    required HealthSettingsState settings,
+    required AppColorsExtension colors,
+    required bool hasError,
+    required bool isStatusSyncing,
+  }) {
+    final timeText = Text(
+      _formatLastSync(settings.lastSyncAt),
+      style: TextStyle(
+        fontSize: 14,
+        color: hasError ? AppColors.error : colors.textSecondary,
+      ),
+    );
+
+    if (isStatusSyncing) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          timeText,
+          const SizedBox(width: 8),
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ],
+      );
+    }
+
+    if (hasError) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          timeText,
+          const SizedBox(width: 6),
+          const Icon(
+            LucideIcons.alertCircle,
+            size: 16,
+            color: AppColors.error,
+          ),
+        ],
+      );
+    }
+
+    return timeText;
+  }
+
+  Widget _buildSyncErrorRow(String message, AppColorsExtension colors) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      child: Container(
+        padding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppColors.rose100,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: AppColors.error.withValues(alpha: 0.3)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(
+              LucideIcons.alertTriangle,
+              size: 16,
+              color: AppColors.warning,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                '同期エラー: $message',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: colors.textSecondary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   String _formatLastSync(DateTime? lastSync) {
     if (lastSync == null) return '未同期';
-    final month = lastSync.month;
-    final day = lastSync.day;
-    final hour = lastSync.hour.toString().padLeft(2, '0');
-    final minute = lastSync.minute.toString().padLeft(2, '0');
-    return '$month月$day日 $hour:$minute';
+    final diff = DateTime.now().difference(lastSync);
+    if (diff.inMinutes < 1) return 'たった今';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}分前';
+    if (diff.inHours < 24) return '${diff.inHours}時間前';
+    if (diff.inDays < 7) return '${diff.inDays}日前';
+    // 1週間以上は日付表記
+    final m = lastSync.month;
+    final d = lastSync.day;
+    final hh = lastSync.hour.toString().padLeft(2, '0');
+    final mm = lastSync.minute.toString().padLeft(2, '0');
+    return '$m月$d日 $hh:$mm';
   }
 }
 
@@ -495,7 +607,13 @@ class HealthSettingsScreen extends ConsumerWidget {
 
 class _PreviewHealthSettings extends StatelessWidget {
   final bool isConnected;
-  const _PreviewHealthSettings({this.isConnected = true});
+  final HealthSyncStatus syncStatus;
+  final String? errorMessage;
+  const _PreviewHealthSettings({
+    this.isConnected = true,
+    this.syncStatus = HealthSyncStatus.idle,
+    this.errorMessage,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -667,72 +785,7 @@ class _PreviewHealthSettings extends StatelessWidget {
           const SizedBox(height: 16),
 
           // Sync Section
-          Container(
-            margin: const EdgeInsets.symmetric(horizontal: 16),
-            decoration: BoxDecoration(
-              color: colors.surface,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: colors.border),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                  child: Text(
-                    '同期',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.bold,
-                      color: colors.textSecondary,
-                      letterSpacing: 0.5,
-                    ),
-                  ),
-                ),
-                ListTile(
-                  contentPadding:
-                      const EdgeInsets.symmetric(horizontal: 16),
-                  title: Text(
-                    '最終同期',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      color: colors.textPrimary,
-                    ),
-                  ),
-                  trailing: Text(
-                    isConnected ? '4月5日 09:30' : '未同期',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: colors.textSecondary,
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton.icon(
-                      onPressed: isConnected ? () {} : null,
-                      icon: const Icon(LucideIcons.refreshCw, size: 18),
-                      label: const Text('今すぐ同期'),
-                      style: OutlinedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        side: BorderSide(
-                          color: isConnected
-                              ? AppColors.primary
-                              : colors.border,
-                        ),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
+          _buildPreviewSyncSection(colors),
 
           const SizedBox(height: 24),
 
@@ -749,6 +802,151 @@ class _PreviewHealthSettings extends StatelessWidget {
           ),
 
           const SizedBox(height: 100),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPreviewSyncSection(AppColorsExtension colors) {
+    final hasError = syncStatus == HealthSyncStatus.error;
+    final isStatusSyncing = syncStatus == HealthSyncStatus.syncing;
+
+    Widget timeText = Text(
+      isConnected ? '5分前' : '未同期',
+      style: TextStyle(
+        fontSize: 14,
+        color: hasError ? AppColors.error : colors.textSecondary,
+      ),
+    );
+
+    Widget trailing;
+    if (isStatusSyncing) {
+      trailing = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          timeText,
+          const SizedBox(width: 8),
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ],
+      );
+    } else if (hasError) {
+      trailing = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          timeText,
+          const SizedBox(width: 6),
+          const Icon(
+            LucideIcons.alertCircle,
+            size: 16,
+            color: AppColors.error,
+          ),
+        ],
+      );
+    } else {
+      trailing = timeText;
+    }
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Text(
+              '同期',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+                color: colors.textSecondary,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              'アプリ起動時と1時間ごとに自動同期します',
+              style: TextStyle(fontSize: 12, color: colors.textHint),
+            ),
+          ),
+          ListTile(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+            title: Text(
+              '最終同期',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: colors.textPrimary,
+              ),
+            ),
+            trailing: trailing,
+          ),
+          if (hasError && errorMessage != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  color: AppColors.rose100,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: AppColors.error.withValues(alpha: 0.3),
+                  ),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(
+                      LucideIcons.alertTriangle,
+                      size: 16,
+                      color: AppColors.warning,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        '同期エラー: $errorMessage',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: colors.textSecondary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: isConnected ? () {} : null,
+                icon: const Icon(LucideIcons.refreshCw, size: 18),
+                label: const Text('今すぐ同期'),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  side: BorderSide(
+                    color:
+                        isConnected ? AppColors.primary : colors.border,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -771,6 +969,22 @@ Widget previewHealthSettingsDisconnected() {
     theme: AppTheme.lightTheme,
     home: const Scaffold(
       body: SafeArea(child: _PreviewHealthSettings(isConnected: false)),
+    ),
+  );
+}
+
+@Preview(name: 'HealthSettingsScreen - Sync Error')
+Widget previewHealthSettingsSyncError() {
+  return MaterialApp(
+    theme: AppTheme.lightTheme,
+    home: const Scaffold(
+      body: SafeArea(
+        child: _PreviewHealthSettings(
+          isConnected: true,
+          syncStatus: HealthSyncStatus.error,
+          errorMessage: 'HealthKitへのアクセスが拒否されました',
+        ),
+      ),
     ),
   );
 }

--- a/fit-connect-mobile/lib/features/health/providers/health_provider.dart
+++ b/fit-connect-mobile/lib/features/health/providers/health_provider.dart
@@ -4,6 +4,9 @@ import 'package:fit_connect_mobile/features/health/data/health_repository.dart';
 
 part 'health_provider.g.dart';
 
+/// ヘルスケア同期の状態
+enum HealthSyncStatus { idle, syncing, success, error }
+
 /// HealthRepository のプロバイダ
 @riverpod
 HealthRepository healthRepository(HealthRepositoryRef ref) {
@@ -25,6 +28,8 @@ class HealthSettings extends _$HealthSettings {
   static const _keySleepEnabled = 'health_sleep_enabled';
   static const _keyMorningDialogEnabled = 'health_morning_dialog_enabled';
   static const _keyLastSync = 'health_last_sync';
+  static const _keyLastSyncStatus = 'health_last_sync_status';
+  static const _keyLastSyncError = 'health_last_sync_error';
 
   @override
   Future<HealthSettingsState> build() async {
@@ -35,6 +40,8 @@ class HealthSettings extends _$HealthSettings {
       isSleepEnabled: prefs.getBool(_keySleepEnabled) ?? false,
       isMorningDialogEnabled: prefs.getBool(_keyMorningDialogEnabled) ?? true,
       lastSyncAt: _parseDateTime(prefs.getString(_keyLastSync)),
+      lastSyncStatus: _parseStatus(prefs.getString(_keyLastSyncStatus)),
+      lastSyncError: prefs.getString(_keyLastSyncError),
     );
   }
 
@@ -83,16 +90,51 @@ class HealthSettings extends _$HealthSettings {
     ref.invalidateSelf();
   }
 
-  /// 最終同期日時を更新
+  /// 最終同期日時を更新（互換性維持のため残置。内部的には updateSyncResult を呼ぶ）
   Future<void> updateLastSyncAt(DateTime dateTime) async {
+    await updateSyncResult(
+      status: HealthSyncStatus.success,
+      error: null,
+      syncedAt: dateTime,
+    );
+  }
+
+  /// 同期結果を保存（status / error / syncedAt をまとめて永続化）
+  ///
+  /// - status: 必須。idle/syncing/success/error
+  /// - error: エラーメッセージ。success 時は null を渡してクリアする
+  /// - syncedAt: 成功時のみ渡す。null の場合は lastSyncAt を更新しない
+  Future<void> updateSyncResult({
+    required HealthSyncStatus status,
+    String? error,
+    DateTime? syncedAt,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_keyLastSync, dateTime.toIso8601String());
+    await prefs.setString(_keyLastSyncStatus, status.name);
+
+    if (error == null) {
+      await prefs.remove(_keyLastSyncError);
+    } else {
+      await prefs.setString(_keyLastSyncError, error);
+    }
+
+    if (syncedAt != null) {
+      await prefs.setString(_keyLastSync, syncedAt.toIso8601String());
+    }
     ref.invalidateSelf();
   }
 
   DateTime? _parseDateTime(String? value) {
     if (value == null) return null;
     return DateTime.tryParse(value);
+  }
+
+  HealthSyncStatus _parseStatus(String? value) {
+    if (value == null) return HealthSyncStatus.idle;
+    for (final s in HealthSyncStatus.values) {
+      if (s.name == value) return s;
+    }
+    return HealthSyncStatus.idle;
   }
 }
 
@@ -103,6 +145,8 @@ class HealthSettingsState {
   final bool isSleepEnabled;
   final bool isMorningDialogEnabled;
   final DateTime? lastSyncAt;
+  final HealthSyncStatus lastSyncStatus;
+  final String? lastSyncError;
 
   const HealthSettingsState({
     required this.isEnabled,
@@ -110,6 +154,8 @@ class HealthSettingsState {
     required this.isSleepEnabled,
     required this.isMorningDialogEnabled,
     this.lastSyncAt,
+    this.lastSyncStatus = HealthSyncStatus.idle,
+    this.lastSyncError,
   });
 
   HealthSettingsState copyWith({
@@ -118,6 +164,8 @@ class HealthSettingsState {
     bool? isSleepEnabled,
     bool? isMorningDialogEnabled,
     DateTime? lastSyncAt,
+    HealthSyncStatus? lastSyncStatus,
+    String? lastSyncError,
   }) =>
       HealthSettingsState(
         isEnabled: isEnabled ?? this.isEnabled,
@@ -126,5 +174,7 @@ class HealthSettingsState {
         isMorningDialogEnabled:
             isMorningDialogEnabled ?? this.isMorningDialogEnabled,
         lastSyncAt: lastSyncAt ?? this.lastSyncAt,
+        lastSyncStatus: lastSyncStatus ?? this.lastSyncStatus,
+        lastSyncError: lastSyncError ?? this.lastSyncError,
       );
 }

--- a/fit-connect-mobile/lib/features/health/providers/health_sync_provider.dart
+++ b/fit-connect-mobile/lib/features/health/providers/health_sync_provider.dart
@@ -11,9 +11,16 @@ import 'package:fit_connect_mobile/services/notification_service.dart';
 
 part 'health_sync_provider.g.dart';
 
-/// 日付をキー文字列に変換するヘルパー
-String dateKey(DateTime dt) =>
-    '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+/// 日付をキー文字列に変換するヘルパー（必ずローカル時刻ベース）
+///
+/// HealthKit の dateFrom と DB から復元した recordedAt のタイムゾーンが
+/// ばらつく可能性があるため、`.toLocal()` で正規化してから日付化する。
+String dateKey(DateTime dt) {
+  final local = dt.toLocal();
+  return '${local.year}-'
+      '${local.month.toString().padLeft(2, '0')}-'
+      '${local.day.toString().padLeft(2, '0')}';
+}
 
 /// HealthKitデータのフィルタリング結果
 class HealthDataFilterResult {
@@ -197,7 +204,11 @@ class HealthSync extends _$HealthSync {
     Error.throwWithStackTrace(lastError!, lastStack ?? StackTrace.current);
   }
 
-  /// 体重同期ロジック（元の _sync から切り出し、振る舞いは同一）
+  /// 体重同期ロジック
+  /// - 既存に message/manual レコードあり → skip（ユーザー入力優先）
+  /// - 既存に healthkit レコードあり & 値が変わっている → UPDATE
+  /// - 既存に healthkit レコードあり & 値が同じ → skip
+  /// - 既存なし → INSERT
   Future<void> _syncWeight(String clientId, DateTime startDate) async {
     final repo = ref.read(healthRepositoryProvider);
     final hasPermission = await repo.hasPermission();
@@ -215,39 +226,81 @@ class HealthSync extends _$HealthSync {
     final weightRepo = WeightRepository();
     final existingRecords = await weightRepo.getWeightRecords(clientId: clientId);
 
-    final filterResult = filterHealthData(
-      healthDataDates: healthData.map((dp) => dp.dateFrom).toList(),
-      existingRecords: existingRecords,
-    );
-    debugPrint(
-      '[HealthSync] Weight: ${filterResult.importIndices.length} to import',
-    );
-
-    int inserted = 0;
-    for (final index in filterResult.importIndices) {
-      final dataPoint = healthData[index];
-      final weightValue =
-          (dataPoint.value as NumericHealthValue).numericValue.toDouble();
-
-      try {
-        await weightRepo.createWeightRecordWithSource(
-          clientId: clientId,
-          weight: weightValue,
-          recordedAt: dataPoint.dateFrom,
-          source: 'healthkit',
-        );
-        inserted++;
-      } catch (e) {
-        debugPrint('[HealthSync] Weight insert failed at $index: $e');
+    // 日付 → 既存レコード のマップを構築（同じ日に複数あれば message/manual 優先）
+    final existingByDate = <String, WeightRecord>{};
+    for (final r in existingRecords) {
+      final key = dateKey(r.recordedAt);
+      final current = existingByDate[key];
+      if (current == null) {
+        existingByDate[key] = r;
+      } else {
+        // 優先度: message > manual > healthkit
+        final priority = {'message': 3, 'manual': 2, 'healthkit': 1};
+        final newP = priority[r.source] ?? 0;
+        final curP = priority[current.source] ?? 0;
+        if (newP > curP) existingByDate[key] = r;
       }
     }
 
-    if (inserted > 0) {
+    int inserted = 0;
+    int updated = 0;
+    int skippedNoChange = 0;
+    int skippedUserSource = 0;
+
+    for (final dataPoint in healthData) {
+      final weightValue =
+          (dataPoint.value as NumericHealthValue).numericValue.toDouble();
+      final key = dateKey(dataPoint.dateFrom);
+      final existing = existingByDate[key];
+
+      try {
+        if (existing == null) {
+          await weightRepo.createWeightRecordWithSource(
+            clientId: clientId,
+            weight: weightValue,
+            recordedAt: dataPoint.dateFrom,
+            source: 'healthkit',
+          );
+          inserted++;
+        } else if (existing.source == 'message' ||
+            existing.source == 'manual') {
+          skippedUserSource++;
+        } else if (existing.source == 'healthkit') {
+          // 値が違うときだけ UPDATE（== 比較は浮動小数誤差に弱いため小数2桁で比較）
+          final sameValue =
+              (existing.weight - weightValue).abs() < 0.005;
+          if (sameValue) {
+            skippedNoChange++;
+          } else {
+            await weightRepo.updateWeightRecord(
+              id: existing.id,
+              weight: weightValue,
+              recordedAt: dataPoint.dateFrom,
+            );
+            updated++;
+            debugPrint(
+              '[HealthSync] Weight: $key updated ${existing.weight} → $weightValue',
+            );
+          }
+        } else {
+          // 未知の source → 安全側で skip
+          skippedUserSource++;
+        }
+      } catch (e) {
+        debugPrint('[HealthSync] Weight write failed for $key: $e');
+      }
+    }
+
+    debugPrint(
+      '[HealthSync] Weight: inserted=$inserted updated=$updated '
+      'skipped(user)=$skippedUserSource skipped(noChange)=$skippedNoChange',
+    );
+
+    if (inserted > 0 || updated > 0) {
       ref.invalidate(weightRecordsProvider);
       ref.invalidate(latestWeightRecordProvider);
       ref.invalidate(weightStatsProvider);
     }
-    debugPrint('[HealthSync] Weight: inserted $inserted');
   }
 
   /// 睡眠同期ロジック（HealthKit から取得 → UPSERT）

--- a/fit-connect-mobile/lib/features/health/providers/health_sync_provider.dart
+++ b/fit-connect-mobile/lib/features/health/providers/health_sync_provider.dart
@@ -102,8 +102,13 @@ class HealthSync extends _$HealthSync {
       status: HealthSyncStatus.syncing,
     );
 
-    final startDate = settings.lastSyncAt ??
-        DateTime.now().subtract(const Duration(days: 30));
+    // HealthKit/Health Connect のクエリ範囲は常に過去30日。
+    // `lastSyncAt` を startDate に使うと、ユーザーが Apple Health で
+    // バックデート登録したサンプル（例: 朝8:57に体重を記録 → 9:35にアプリ起動 →
+    // lastSyncAt=9:35 で次回 sync すると 8:57 のサンプルがクエリ範囲外）を
+    // 取りこぼすため、毎回フル30日を読み直して `filterHealthData` /
+    // `upsertObjectiveData` の冪等性に依存する。
+    final startDate = DateTime.now().subtract(const Duration(days: 30));
 
     String? weightError;
     String? sleepError;

--- a/fit-connect-mobile/lib/features/health/providers/health_sync_provider.dart
+++ b/fit-connect-mobile/lib/features/health/providers/health_sync_provider.dart
@@ -7,6 +7,7 @@ import 'package:fit_connect_mobile/features/weight_records/models/weight_record_
 import 'package:fit_connect_mobile/features/auth/providers/current_user_provider.dart';
 import 'package:fit_connect_mobile/features/weight_records/providers/weight_records_provider.dart';
 import 'package:fit_connect_mobile/features/sleep_records/providers/sleep_records_provider.dart';
+import 'package:fit_connect_mobile/services/notification_service.dart';
 
 part 'health_sync_provider.g.dart';
 
@@ -94,42 +95,101 @@ class HealthSync extends _$HealthSync {
       return;
     }
 
+    final settingsNotifier = ref.read(healthSettingsProvider.notifier);
+
+    // 同期開始: status を syncing に
+    await settingsNotifier.updateSyncResult(
+      status: HealthSyncStatus.syncing,
+    );
+
     final startDate = settings.lastSyncAt ??
         DateTime.now().subtract(const Duration(days: 30));
 
-    bool weightOk = false;
-    bool sleepOk = false;
+    String? weightError;
+    String? sleepError;
 
-    // 体重同期（独立try/catch）
+    // 体重同期（リトライ付き）
     if (settings.isWeightEnabled) {
       try {
-        await _syncWeight(clientId, startDate);
-        weightOk = true;
-      } catch (e, st) {
-        debugPrint('[HealthSync] Weight sync failed: $e\n$st');
+        await _runWithRetry(
+          () => _syncWeight(clientId, startDate),
+          label: 'Weight',
+        );
+      } catch (e) {
+        weightError = '体重: $e';
+        debugPrint('[HealthSync] Weight sync failed after retries: $e');
       }
-    } else {
-      weightOk = true; // 無効化されてるので成功扱い
     }
 
-    // 睡眠同期（独立try/catch）
+    // 睡眠同期（リトライ付き）
     if (settings.isSleepEnabled) {
       try {
-        await _syncSleep(clientId, startDate);
-        sleepOk = true;
-      } catch (e, st) {
-        debugPrint('[HealthSync] Sleep sync failed: $e\n$st');
+        await _runWithRetry(
+          () => _syncSleep(clientId, startDate),
+          label: 'Sleep',
+        );
+      } catch (e) {
+        sleepError = '睡眠: $e';
+        debugPrint('[HealthSync] Sleep sync failed after retries: $e');
       }
-    } else {
-      sleepOk = true;
     }
 
-    // 両方成功時のみ lastSyncAt 更新（失敗した片方は次回再試行）
-    if (weightOk && sleepOk) {
-      await ref
-          .read(healthSettingsProvider.notifier)
-          .updateLastSyncAt(DateTime.now());
+    final hasError = weightError != null || sleepError != null;
+
+    if (!hasError) {
+      // 全成功 → lastSyncAt 更新 + status=success
+      await settingsNotifier.updateSyncResult(
+        status: HealthSyncStatus.success,
+        error: null,
+        syncedAt: DateTime.now(),
+      );
+    } else {
+      // 一部または全失敗 → status=error, lastSyncAt は更新しない
+      final combinedMessage =
+          [weightError, sleepError].whereType<String>().join(' / ');
+      await settingsNotifier.updateSyncResult(
+        status: HealthSyncStatus.error,
+        error: combinedMessage,
+      );
+
+      // ローカル通知（iOS/Android のみ）
+      if (!kIsWeb &&
+          (defaultTargetPlatform == TargetPlatform.iOS ||
+              defaultTargetPlatform == TargetPlatform.android)) {
+        await NotificationService.showSyncErrorNotification(combinedMessage);
+      }
     }
+  }
+
+  /// 指数バックオフでリトライ。最大3回（初回 + 2リトライ）、1s/2s 待機。
+  Future<void> _runWithRetry(
+    Future<void> Function() task, {
+    required String label,
+  }) async {
+    const maxAttempts = 3;
+    Duration delay = const Duration(seconds: 1);
+    Object? lastError;
+    StackTrace? lastStack;
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await task();
+        if (attempt > 1) {
+          debugPrint('[HealthSync] $label: succeeded on attempt $attempt');
+        }
+        return;
+      } catch (e, st) {
+        lastError = e;
+        lastStack = st;
+        debugPrint(
+          '[HealthSync] $label attempt $attempt/$maxAttempts failed: $e',
+        );
+        if (attempt < maxAttempts) {
+          await Future.delayed(delay);
+          delay *= 2;
+        }
+      }
+    }
+    Error.throwWithStackTrace(lastError!, lastStack ?? StackTrace.current);
   }
 
   /// 体重同期ロジック（元の _sync から切り出し、振る舞いは同一）

--- a/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
+++ b/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fit_connect_mobile/core/theme/app_colors.dart';
 import 'package:fit_connect_mobile/features/home/presentation/screens/home_screen.dart';
@@ -11,6 +12,8 @@ import 'package:fit_connect_mobile/features/goals/presentation/widgets/goal_achi
 import 'package:fit_connect_mobile/features/auth/providers/current_user_provider.dart';
 import 'package:fit_connect_mobile/features/messages/providers/messages_provider.dart';
 import 'package:fit_connect_mobile/features/workout/presentation/screens/workout_screen.dart';
+import 'package:fit_connect_mobile/features/health/providers/health_provider.dart';
+import 'package:fit_connect_mobile/features/health/providers/health_sync_provider.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 
 class MainScreen extends ConsumerStatefulWidget {
@@ -25,11 +28,51 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   int _recordsTabIndex = 0;
   bool _initialized = false;
 
+  /// 最後にホーム遷移トリガで sync を発火した時刻（重複発火防止）
+  DateTime? _lastHomeTriggerSyncAt;
+
+  @override
+  void initState() {
+    super.initState();
+    // ホーム画面マウント時にヘルスケア同期を試行（アプリ起動時 / 再ログイン時）
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _maybeSyncOnHomeEntry();
+    });
+  }
+
   void _navigateToRecordsTab(int tabIndex) {
     setState(() {
       _currentIndex = 3;
       _recordsTabIndex = tabIndex;
     });
+  }
+
+  /// ホーム画面に到達したタイミングで同期を発火する。
+  /// 直近 5 分以内に同期済みならスキップ（_AuthLoadingScreen の起動時同期や
+  /// Timer.periodic / resume 経由の同期との重複を回避）。
+  Future<void> _maybeSyncOnHomeEntry() async {
+    if (!mounted) return;
+    final settings = ref.read(healthSettingsProvider).valueOrNull;
+    if (settings == null || !settings.isEnabled) return;
+
+    final now = DateTime.now();
+    if (_lastHomeTriggerSyncAt != null &&
+        now.difference(_lastHomeTriggerSyncAt!) < const Duration(minutes: 5)) {
+      return;
+    }
+    final lastSync = settings.lastSyncAt;
+    if (lastSync != null &&
+        now.difference(lastSync) < const Duration(minutes: 5)) {
+      return;
+    }
+
+    _lastHomeTriggerSyncAt = now;
+    try {
+      await ref.read(healthSyncProvider.notifier).syncOnLaunch();
+      debugPrint('[MainScreen] Home遷移時の同期完了');
+    } catch (e) {
+      debugPrint('[MainScreen] Home遷移時の同期エラー: $e');
+    }
   }
 
   List<Widget> get _screens => [
@@ -137,7 +180,13 @@ class _MainScreenState extends ConsumerState<MainScreen> {
     final colors = AppColors.of(context);
     final isSelected = _currentIndex == index;
     return InkWell(
-      onTap: () => setState(() => _currentIndex = index),
+      onTap: () {
+        setState(() => _currentIndex = index);
+        // ホームタブに切り替わった時もヘルスケア同期を試行（5分レート制限あり）
+        if (index == 0) {
+          _maybeSyncOnHomeEntry();
+        }
+      },
       customBorder: const CircleBorder(),
       child: Container(
         padding: const EdgeInsets.all(12),

--- a/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
+++ b/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
@@ -28,7 +28,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   int _recordsTabIndex = 0;
   bool _initialized = false;
 
-  /// 最後にホーム遷移トリガで sync を発火した時刻（重複発火防止）
+  /// 最後にホーム遷移トリガで sync を発火した時刻（連打防止）
   DateTime? _lastHomeTriggerSyncAt;
 
   @override
@@ -48,21 +48,23 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   }
 
   /// ホーム画面に到達したタイミングで同期を発火する。
-  /// 直近 5 分以内に同期済みならスキップ（_AuthLoadingScreen の起動時同期や
-  /// Timer.periodic / resume 経由の同期との重複を回避）。
+  /// 連打防止のため直近 30 秒以内のみスキップ。
+  /// HealthKit のデータを即座に画面に反映させるのが目的なので、
+  /// `lastSyncAt` ベースの長時間レート制限はかけない（_AuthLoadingScreen の
+  /// 起動時同期と並行することはあるが、HealthKit の呼び出しは軽量で
+  /// `filterHealthData` / `upsertObjectiveData` が冪等なので実害はない）。
   Future<void> _maybeSyncOnHomeEntry() async {
     if (!mounted) return;
-    final settings = ref.read(healthSettingsProvider).valueOrNull;
-    if (settings == null || !settings.isEnabled) return;
+
+    // settings provider が cold start 直後でまだ resolve していないケースに備え、
+    // valueOrNull ではなく future を await する
+    final settings = await ref.read(healthSettingsProvider.future);
+    if (!mounted) return;
+    if (!settings.isEnabled) return;
 
     final now = DateTime.now();
     if (_lastHomeTriggerSyncAt != null &&
-        now.difference(_lastHomeTriggerSyncAt!) < const Duration(minutes: 5)) {
-      return;
-    }
-    final lastSync = settings.lastSyncAt;
-    if (lastSync != null &&
-        now.difference(lastSync) < const Duration(minutes: 5)) {
+        now.difference(_lastHomeTriggerSyncAt!) < const Duration(seconds: 30)) {
       return;
     }
 
@@ -182,7 +184,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
     return InkWell(
       onTap: () {
         setState(() => _currentIndex = index);
-        // ホームタブに切り替わった時もヘルスケア同期を試行（5分レート制限あり）
+        // ホームタブに切り替わった時もヘルスケア同期を試行（30秒の連打防止のみ）
         if (index == 0) {
           _maybeSyncOnHomeEntry();
         }

--- a/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
+++ b/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
@@ -28,7 +28,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   int _recordsTabIndex = 0;
   bool _initialized = false;
 
-  /// 最後にホーム遷移トリガで sync を発火した時刻（連打防止）
+  /// 最後にホーム遷移トリガで sync を発火した時刻（重複発火防止）
   DateTime? _lastHomeTriggerSyncAt;
 
   @override
@@ -48,9 +48,8 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   }
 
   /// ホーム画面に到達したタイミングで同期を発火する。
-  /// 連打/極短期間の重複だけを防ぐため、直近 30 秒以内のみスキップ。
-  /// HealthKit のデータを即座に画面に反映させるのが目的なので、
-  /// `lastSyncAt` ベースの長時間レート制限はかけない。
+  /// 直近 5 分以内に同期済みならスキップ（_AuthLoadingScreen の起動時同期や
+  /// Timer.periodic / resume 経由の同期との重複を回避）。
   Future<void> _maybeSyncOnHomeEntry() async {
     if (!mounted) return;
     final settings = ref.read(healthSettingsProvider).valueOrNull;
@@ -58,7 +57,12 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
     final now = DateTime.now();
     if (_lastHomeTriggerSyncAt != null &&
-        now.difference(_lastHomeTriggerSyncAt!) < const Duration(seconds: 30)) {
+        now.difference(_lastHomeTriggerSyncAt!) < const Duration(minutes: 5)) {
+      return;
+    }
+    final lastSync = settings.lastSyncAt;
+    if (lastSync != null &&
+        now.difference(lastSync) < const Duration(minutes: 5)) {
       return;
     }
 

--- a/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
+++ b/fit-connect-mobile/lib/features/home/presentation/screens/main_screen.dart
@@ -28,7 +28,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   int _recordsTabIndex = 0;
   bool _initialized = false;
 
-  /// 最後にホーム遷移トリガで sync を発火した時刻（重複発火防止）
+  /// 最後にホーム遷移トリガで sync を発火した時刻（連打防止）
   DateTime? _lastHomeTriggerSyncAt;
 
   @override
@@ -48,8 +48,9 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   }
 
   /// ホーム画面に到達したタイミングで同期を発火する。
-  /// 直近 5 分以内に同期済みならスキップ（_AuthLoadingScreen の起動時同期や
-  /// Timer.periodic / resume 経由の同期との重複を回避）。
+  /// 連打/極短期間の重複だけを防ぐため、直近 30 秒以内のみスキップ。
+  /// HealthKit のデータを即座に画面に反映させるのが目的なので、
+  /// `lastSyncAt` ベースの長時間レート制限はかけない。
   Future<void> _maybeSyncOnHomeEntry() async {
     if (!mounted) return;
     final settings = ref.read(healthSettingsProvider).valueOrNull;
@@ -57,12 +58,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
     final now = DateTime.now();
     if (_lastHomeTriggerSyncAt != null &&
-        now.difference(_lastHomeTriggerSyncAt!) < const Duration(minutes: 5)) {
-      return;
-    }
-    final lastSync = settings.lastSyncAt;
-    if (lastSync != null &&
-        now.difference(lastSync) < const Duration(minutes: 5)) {
+        now.difference(_lastHomeTriggerSyncAt!) < const Duration(seconds: 30)) {
       return;
     }
 

--- a/fit-connect-mobile/lib/services/notification_service.dart
+++ b/fit-connect-mobile/lib/services/notification_service.dart
@@ -255,6 +255,41 @@ class NotificationService {
     }
   }
 
+  /// バックグラウンド同期失敗時のローカル通知
+  ///
+  /// 同期エラー専用の固定 ID (9001) を使うため、連続して呼ばれた場合は
+  /// 既存の通知を上書きする（通知トレイに溜まらない）。
+  static Future<void> showSyncErrorNotification(String message) async {
+    try {
+      const androidDetails = AndroidNotificationDetails(
+        'high_importance_channel',
+        '重要な通知',
+        channelDescription: 'このチャンネルは重要な通知に使用されます',
+        importance: Importance.high,
+        priority: Priority.high,
+      );
+      const iosDetails = DarwinNotificationDetails();
+      const details = NotificationDetails(
+        android: androidDetails,
+        iOS: iosDetails,
+      );
+
+      final body = message.length > 120
+          ? '${message.substring(0, 120)}…'
+          : message;
+
+      await _localNotifications.show(
+        9001, // 固定ID（同期エラー専用、上書きされる）
+        'ヘルスケア同期に失敗しました',
+        body,
+        details,
+        payload: 'health_sync_error',
+      );
+    } catch (e) {
+      print('[NotificationService] 同期エラー通知エラー: $e');
+    }
+  }
+
   /// トークンリフレッシュハンドラ
   static Future<void> _handleTokenRefresh(String newToken) async {
     try {


### PR DESCRIPTION
## Summary

Implements periodic background synchronization of health data (weight and sleep) with comprehensive error handling, retry logic, and user-facing status indicators. Adds sync state tracking, error notifications, and improves the sync UX with real-time status updates.

## Key Changes

### Health Sync Provider (`health_sync_provider.dart`)
- **Retry logic**: Added `_runWithRetry()` with exponential backoff (max 3 attempts, 1s/2s delays) for resilient sync operations
- **Sync state management**: Introduced `HealthSyncStatus` enum (idle/syncing/success/error) to track sync progress
- **Error handling**: Separate try/catch for weight and sleep sync; combined error messages on partial failures
- **Weight sync improvements**:
  - Refactored to handle INSERT/UPDATE/SKIP logic based on existing records
  - Respects user-entered data (message/manual sources) over HealthKit data
  - Detects unchanged values to avoid unnecessary updates
  - Fixed date key generation to use local time consistently
- **Notification support**: Shows local notifications on sync errors (iOS/Android only)
- **Query range fix**: Always queries past 30 days instead of using `lastSyncAt` to catch backdated entries

### Health Settings Provider (`health_provider.dart`)
- **New enum**: `HealthSyncStatus` with four states for sync lifecycle
- **Persistent state**: Added `lastSyncStatus` and `lastSyncError` fields to `HealthSettingsState`
- **New method**: `updateSyncResult()` consolidates status/error/timestamp updates into single operation
- **Backward compatibility**: Kept `updateLastSyncAt()` as wrapper around `updateSyncResult()`

### Health Settings Screen (`health_settings_screen.dart`)
- **Sync status display**: 
  - Shows loading spinner during sync
  - Displays error icon with red text on failure
  - Relative time format ("5分前", "2時間前") instead of absolute timestamps
- **Error details**: Conditional error message box with alert icon and error text
- **Periodic sync description**: Added helper text explaining auto-sync behavior
- **Manual sync feedback**: Enhanced snackbar shows error details on failure
- **Helper methods**: Extracted `_buildSyncStatusTrailing()` and `_buildSyncErrorRow()` for cleaner code
- **Preview updates**: Added sync error preview state to component showcase

### App Lifecycle (`app.dart`)
- **Periodic sync timer**: 60-minute interval background sync when app is in foreground
- **Resume sync**: Triggers sync on app resume if last sync was >1 hour ago
- **Launch sync**: Initial sync on app startup (coordinated with MainScreen)
- **Debouncing**: Prevents rapid-fire syncs with 30-second cooldown

### Main Screen (`main_screen.dart`)
- **Home entry sync**: Triggers sync when navigating to home tab (with 30-second debounce)
- **Async initialization**: Uses `addPostFrameCallback` to sync after first frame
- **Settings check**: Respects health sync enabled setting before attempting sync

### Notification Service (`notification_service.dart`)
- **Sync error notifications**: New `showSyncErrorNotification()` method with fixed ID (9001) to prevent notification spam
- **Message truncation**: Limits error message to 120 characters in notification body

### Documentation
- Updated task progress (1.4 complete, overall 22%)
- Added lessons learned about background sync strategy and why `workmanager` was not used

## Implementation Details

- **Idempotent operations**: Weight/sleep sync uses upsert logic to safely retry without duplicates
- **Timezone handling**: Fixed `dateKey()` to normalize all datetimes to local time before comparison
- **Floating-point comparison**: Weight value changes use 0.005 tolerance to avoid false positives
- **Source priority**: When multiple records exist for same date, respects priority: message > manual > healthkit
- **Error aggregation**: Combines weight and sleep errors into single message for user display
- **State persistence**: All sync state (status, error, timestamp) persisted to SharedPreferences

https://claude.ai/code/session_01FJtvm7EK8tLEknHEuoznFN