### PR TITLE
feat(web): improve iPad touch interactions

### DIFF
--- a/fit-connect/src/app/globals.css
+++ b/fit-connect/src/app/globals.css
@@ -97,3 +97,38 @@ input[type="number"]::-webkit-outer-spin-button {
   width: 1.5em;
   cursor: pointer;
 }
+
+/* iPad / タッチデバイス対応 */
+@layer base {
+  html {
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* タッチデバイスではダブルタップズームを抑制し、ドラッグ操作を安定化 */
+  body {
+    touch-action: manipulation;
+  }
+
+  /* iOS Safari でフォーム要素が自動ズームされないよう16px以上を確保 */
+  @supports (-webkit-touch-callout: none) {
+    input,
+    textarea,
+    select {
+      font-size: 16px;
+    }
+  }
+}
+
+/* ホバー効果をホバー可能デバイスに限定（iPadでホバー残留を防ぐ） */
+@media (hover: none) {
+  .hover\:bg-gray-50:hover,
+  .hover\:bg-gray-100:hover,
+  .hover\:bg-\[\#F8FAFC\]:hover,
+  .hover\:bg-\[\#fff\]:hover,
+  .hover\:text-gray-600:hover,
+  .hover\:text-\[\#475569\]:hover {
+    background-color: revert;
+    color: revert;
+  }
+}

--- a/fit-connect/src/app/layout.tsx
+++ b/fit-connect/src/app/layout.tsx
@@ -23,6 +23,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className={`${jakarta.variable} ${noto.variable}`}>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+      </head>
       <body className="font-sans antialiased">
         <header className="fixed top-0 left-0 right-0 h-14 z-50 bg-white border-b border-[#E2E8F0] flex items-center justify-between px-6">
           <div className="flex items-center gap-2.5">

--- a/fit-connect/src/components/schedule/AssignmentMiniCard.tsx
+++ b/fit-connect/src/components/schedule/AssignmentMiniCard.tsx
@@ -59,6 +59,7 @@ export const AssignmentMiniCard: React.FC<AssignmentMiniCardProps> = ({
           borderLeft: `3px solid ${colors.border}`,
           color: colors.text,
           borderRadius: '4px',
+          touchAction: 'none',
         }}
         {...(!isDragOverlay ? listeners : {})}
         {...(!isDragOverlay ? attributes : {})}
@@ -91,6 +92,7 @@ export const AssignmentMiniCard: React.FC<AssignmentMiniCardProps> = ({
         borderLeft: `3px solid ${colors.border}`,
         color: colors.text,
         borderRadius: '6px',
+        touchAction: 'none',
       }}
       {...(!isDragOverlay ? listeners : {})}
       {...(!isDragOverlay ? attributes : {})}
@@ -100,7 +102,7 @@ export const AssignmentMiniCard: React.FC<AssignmentMiniCardProps> = ({
         <button
           onClick={(e) => { e.stopPropagation(); onDelete(assignment.id); }}
           onPointerDown={(e) => e.stopPropagation()}
-          className="absolute top-1 right-1 opacity-0 group-hover/card:opacity-100 transition-opacity p-0.5 rounded hover:bg-red-100 text-gray-400 hover:text-red-500"
+          className="absolute top-1 right-1 opacity-0 group-hover/card:opacity-100 transition-opacity w-8 h-8 flex items-center justify-center rounded hover:bg-red-100 text-gray-400 hover:text-red-500"
         >
           <X size={14} />
         </button>

--- a/fit-connect/src/components/schedule/CalendarEvent.tsx
+++ b/fit-connect/src/components/schedule/CalendarEvent.tsx
@@ -72,6 +72,7 @@ export const CalendarEvent: React.FC<CalendarEventProps> = ({ event, onClick, vi
                     color: colors.text,
                     opacity: statusStyle.opacity,
                     borderRadius: '4px',
+                    touchAction: 'none',
                 }}
                 {...(!isDragOverlay ? listeners : {})}
                 {...(!isDragOverlay ? attributes : {})}
@@ -97,6 +98,7 @@ export const CalendarEvent: React.FC<CalendarEventProps> = ({ event, onClick, vi
                 color: colors.text,
                 opacity: statusStyle.opacity,
                 borderRadius: '6px',
+                touchAction: 'none',
             }}
             {...(!isDragOverlay ? listeners : {})}
             {...(!isDragOverlay ? attributes : {})}

--- a/fit-connect/src/components/schedule/CalendarView.tsx
+++ b/fit-connect/src/components/schedule/CalendarView.tsx
@@ -6,7 +6,7 @@ import { ScheduleSkeleton } from './ScheduleSkeleton';
 import { format, startOfMonth, endOfMonth, startOfWeek, isSameMonth, isSameDay, addMonths, addDays, getDay } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { ChevronLeft, ChevronRight, Plus, Search, ClipboardList, Calendar, Clock, CheckCircle2, AlertTriangle } from 'lucide-react';
-import { DndContext, DragOverlay, closestCenter, DragEndEvent, DragStartEvent, useDroppable, useSensor, useSensors, PointerSensor } from '@dnd-kit/core';
+import { DndContext, DragOverlay, closestCenter, DragEndEvent, DragStartEvent, useDroppable, useSensor, useSensors, MouseSensor, TouchSensor } from '@dnd-kit/core';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { supabase } from '@/lib/supabase';
 import { getSessions, Session } from '@/lib/supabase/getSessions';
@@ -95,10 +95,11 @@ export default function CalendarView() {
     const [pendingTemplateDrop, setPendingTemplateDrop] = useState<{ planId: string; date: string; hour?: number } | null>(null);
 
     const sensors = useSensors(
-        useSensor(PointerSensor, {
-            activationConstraint: {
-                distance: 8,
-            },
+        useSensor(MouseSensor, {
+            activationConstraint: { distance: 8 },
+        }),
+        useSensor(TouchSensor, {
+            activationConstraint: { delay: 250, tolerance: 8 },
         })
     );
 

--- a/fit-connect/src/components/workout/CalendarDayCell.tsx
+++ b/fit-connect/src/components/workout/CalendarDayCell.tsx
@@ -20,6 +20,7 @@ function AssignmentCard({ assignment, onDelete }: AssignmentCardProps) {
   const style = {
     transform: CSS.Translate.toString(transform),
     opacity: isDragging ? 0.4 : 1,
+    touchAction: 'none' as const,
   }
 
   const isSession = assignment.plan?.plan_type === 'session'
@@ -49,7 +50,7 @@ function AssignmentCard({ assignment, onDelete }: AssignmentCardProps) {
         <button
           onPointerDown={(e) => e.stopPropagation()}
           onClick={() => onDelete(assignment.id)}
-          className="text-white/70 hover:text-white w-5 h-5 flex items-center justify-center rounded transition-colors text-sm"
+          className="text-white/70 hover:text-white w-8 h-8 flex items-center justify-center rounded transition-colors text-sm"
         >
           ✕
         </button>

--- a/fit-connect/src/components/workout/TemplatePanel.tsx
+++ b/fit-connect/src/components/workout/TemplatePanel.tsx
@@ -29,6 +29,7 @@ function DraggableTemplateCard({
   const style = {
     transform: CSS.Translate.toString(transform),
     opacity: isDragging ? 0.5 : 1,
+    touchAction: 'none' as const,
   }
 
   const categoryLabel =


### PR DESCRIPTION
- Add viewport meta tag for proper iPad Safari rendering
- Add touch-action: manipulation and disable tap highlight to suppress
  double-tap zoom and stabilize drag operations
- Force 16px font-size on iOS for form fields to prevent auto-zoom
- Disable lingering hover states on touch-only devices via @media (hover: none)
- Switch dnd-kit from PointerSensor to MouseSensor + TouchSensor with a
  250ms long-press activation, so scrolling and dragging coexist on iPad
- Add touch-action: none to draggable cards (calendar events, assignment
  mini cards, workout templates) for stable drag once started
- Enlarge small delete-button hit areas from 20px to 32px (44px-aware)

https://claude.ai/code/session_01GmoevpCHFBZydsHGKmnENV