### PR TITLE
chore: Codex 連携用 AGENTS.md とプロジェクト設定を追加

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+# Codex CLI プロジェクト設定 — FIT-CONNECT monorepo
+#
+# プロジェクト固有の Codex 動作のみをここに置く。
+# 開発ルール・構成・運用方針の正本は AGENTS.md → CLAUDE.md を参照すること。
+
+[shell_environment_policy]
+# Codex が起動するシェルへ渡す環境変数のポリシー（core: 必要最小限のみ継承）
+inherit = "core"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md — FIT-CONNECT Monorepo
+
+このファイルは OpenAI Codex など `AGENTS.md` 規約に対応したエージェント向けの入口です。
+
+## 正本は CLAUDE.md
+
+このプロジェクトの開発ルール・構成・運用方針は **[`CLAUDE.md`](./CLAUDE.md) を正本**とします。
+内容の二重管理（ドリフト）を避けるため、ここには規約を複製しません。
+
+**作業を始める前に必ず [`CLAUDE.md`](./CLAUDE.md) を読み、その指示に従うこと。**
+
+各サブプロジェクトにも同様に正本となる `CLAUDE.md` があります:
+
+- Web (Trainer App): [`fit-connect/CLAUDE.md`](./fit-connect/CLAUDE.md)
+- Mobile (Client App): [`fit-connect-mobile/CLAUDE.md`](./fit-connect-mobile/CLAUDE.md)
+
+## 要点（詳細は CLAUDE.md 参照）
+
+- Web (Next.js 15) と Mobile (Flutter) を**単一の Git リポジトリ**で管理するモノレポ
+- 共有バックエンドは Supabase（ルート直下 `supabase/` が真の所在）
+- 運用ブランチは `main`（本番）と `develop/<version>`（開発、現在 `develop/1.0.0`）
+- **新規機能・バグ修正は必ず作業ブランチを切ってから着手**し、PR は `develop/<version>` へ向ける
+- `.env` ファイルは参照しないこと


### PR DESCRIPTION
## 概要

OpenAI Codex など `AGENTS.md` 規約に対応したエージェント向けに、Codex 連携用のファイルを整備します。

## 背景

ブランチ作業中に自動生成された Codex 用ファイル（`.agents/skills/`、`.codex/agents/*.toml`、`AGENTS.md`）が混入していました。これらは以下の問題を含んでいたため、正しい形に整備し直しました。

- `.Codex`（大文字C）パスが実ディレクトリ `.codex` と不一致
- `.agents/skills/` は `.claude/skills/` の単なる重複ミラー
- `.codex/config.toml` が Claude Code 用 env 変数（`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`）をセット

## 変更内容

### 追加
- `AGENTS.md`（**ルート直下のみ**）
  - モノレポ全体の入口。各 `CLAUDE.md`（ルート / fit-connect / fit-connect-mobile）を**正本として参照する薄いポインタ**
  - サブプロジェクト個別の `AGENTS.md` は置かない（ツールが重複して読みコンテキストを汚染するのを避けるため）
- `.codex/config.toml`
  - Codex 正規の `shell_environment_policy` のみ。Claude 用 env は除去

### 不採用（削除）
- `.agents/skills/`（`.claude/skills/` の重複ミラー）
- `.codex/agents/*.toml`（`.claude/agents/` と重複、かつ Codex 標準形式でない）

## 設計方針

開発ルールの正本は `CLAUDE.md` に一本化。`AGENTS.md` はそこへ誘導するだけにすることで、ルール更新時に `CLAUDE.md` のみ修正すれば Codex / Claude 両方に反映される。重複を避けることでエージェントのコンテキスト汚染も防ぐ。

## 影響範囲

ドキュメント / エージェント設定ファイルのみ。アプリのコード・ビルドへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)