### PR TITLE
feat: メッセージ会話/記録分離の基盤（tags統一）

### DIFF
--- a/docs/tasks/2026-06-07-message-record-conversation-tabs-design.md
+++ b/docs/tasks/2026-06-07-message-record-conversation-tabs-design.md
@@ -1,0 +1,172 @@
+# メッセージ画面 会話／記録 表示分離 — 設計書
+
+- **日付**: 2026-06-07
+- **対象**: fit-connect（Web / Trainer）、fit-connect-mobile（Mobile / Client）、共有 Supabase
+- **ステータス**: 設計合意済み（ブレスト完了）→ 実装計画（writing-plans）待ち
+
+---
+
+## 1. 背景・課題
+
+メッセージ画面で、通常の会話と各種記録（食事・体重・運動）が**同一タイムラインに混在**している。
+
+- 通常の会話中に記録を送ると、**会話が途切れる**
+- 記録が**送りづらい** / 後から**記録だけ振り返りにくい**
+
+## 2. コンセプト（死守ライン）
+
+> **「メッセージ上で記録と報告が同時にできる」**
+
+このアプリの核となる体験。**この一体感を壊さないことが最優先**。分離を進めるあまりコンセプトを殺してはならない。
+
+## 3. 設計大原則
+
+- **① 記録を"送る"のは会話と一体** — 入力欄は1つ。記録も会話も同じ場所から送る
+- **② 記録を"見る"時だけ分離** — フィルタ / トグル / タブ / パネルで切り替え
+- **❌ 完全分離は不採用** — 記録を別画面・別入力に追い出すとコンセプトが壊れるため、候補から除外
+
+> この「① 送信は一体 / ② 閲覧だけ分離」が全設計の判断基準。
+
+---
+
+## 4. 現状（コードベース調査結果）
+
+### 4.1 記録判定が Web / Mobile でバラバラ
+- **Mobile**: `tags` カラム（例 `['#食事:朝食']`）で判定
+- **Web**: `content` 本文先頭の文字列パース（`recordCardParser.ts`）で判定。`tags` カラムは未使用
+
+### 4.2 `tags` は送信時には入らず、webhook が"後付け"している ⚠️
+- 送信コード（Web/Mobile）は `tags` を一切書いていない
+- Edge Function `parse-message-tags` が insert 後に**非同期で付与**
+- webhook の判定正規表現は **`#食事 / #体重 / #運動` のみ**
+
+### 4.3 ワークアウト達成メッセージは `tags` が付かない ⚠️⚠️
+- `本日のワークアウトプラン「…」を達成しました！` は `#` が無いため webhook 対象外 → **`tags` 空のまま**
+- Web は `recordCardParser` で記録（achievement）として表示済み
+- → このまま `tags` 統一すると、**達成報告が全部「会話」に誤分類される**
+
+### 4.4 `tags` のデフォルトは空配列 `{}`（NULLではない）
+- 判定は **`cardinality(tags) > 0`** で行う（`IS NOT NULL` だけだと空配列を記録扱いして全件記録になる）
+
+---
+
+## 5. データ基盤設計（フェーズ1）
+
+### 5.1 判定基準の一本化
+- **記録 = `cardinality(tags) > 0` / 会話 = `tags` 空**
+- Web / Mobile の「記録か会話か」判定をこの基準に統一する
+
+### 5.2 3点セット（`tags` を"正"として機能させるための前提）
+1. **送信時に `tags` を確実に付与する**
+   - Mobile: 構造化フォーム（`structured_tag_form`）が生成するタグを `tags` カラムへ**直接書く**
+   - Web: 送信API（`messages/send`）で記録形式なら `tags` を埋める（トレーナーは基本記録を送らないが整合のため）
+   - webhook は補完/バックアップとして整理。**送信側付与により送信直後から正しく分類**され、リアルタイム表示でも分類がブレない
+2. **全種類の記録をタグ対象にする**
+   - 特に**ワークアウト達成**に正規タグを付与（タグ規約は実装時に決定。例: `#運動:達成`）
+3. **既存データのマイグレーション**
+   - `cardinality(tags)=0` かつ `content` が記録パターンのものを、`content` パースで `tags` 補完
+   - 対象: webhook 導入前の記録 / ワークアウト達成 / AI食事（`metadata.meal_estimation`）漏れ
+   - **規模は実装直前に本番DBで計測**（read-only SQL は調査済み・下記参照）
+
+### 5.3 型 / モデル更新
+- Web: `src/types/client.ts` の `Message` 型に `tags` を追加
+- Mobile: `message_model.dart` は `tags` 対応済み
+- `fit-connect/CLAUDE.md` の **古い `messages` スキーマ記述を修正**（`tags`/`metadata` 未記載・誤記あり）
+
+---
+
+## 6. Mobile UI 設計（フェーズ2）
+
+### 6.1 案A: 混在ベース ＋ 切替トグル
+- 画面上部にトグル **「すべて / 記録」**（デフォルト = すべて = 混在）
+- フィルタ状態は **enum: `all` / `recordsOnly` / `chatOnly`** で保持
+  - 案Aでは `all` / `recordsOnly` を使用。`chatOnly` は将来（案B）で有効化
+- **入力欄は一体のまま**（メッセージ＋記録、全状態共通）
+
+### 6.2 挙動
+- **「記録のみ」表示中に通常メッセージを送ったら → 自動で「すべて」に戻す**（送ったものが見えないと混乱するため）
+- 記録ゼロ時の**空状態**プレースホルダを用意
+
+### 6.3 将来拡張（案B / スコープ外）
+- enum に `chatOnly` を加え、トグルを **3タブ（混合 / 会話 / 記録）** に拡張
+- データ層・フィルタロジックは案Aのものを流用（**作り直し不要**）
+
+---
+
+## 7. Web UI 設計（フェーズ3）
+
+### 7.1 案②: 会話メイン ＋ 記録サイドパネル
+- **左**: 会話（メイン。横長画面を活かして広く）
+- **右**: 記録サイドパネル（**開閉式・デフォルト開**）
+- トレーナーは記録を**見る側**なので、パネルは**閲覧専用**（送信フロー不要）
+
+### 7.2 パネル中身（B＋C）
+- **上部**: サマリー（今日のカロリー/PFC、体重推移のミニグラフ）
+- **中部**: フィルタチップ（全 / 食事 / 体重 / 運動）
+- **下部**: 記録ログ（時系列）
+
+---
+
+## 8. 実装フェーズ（依存順）
+
+1. **基盤（tags 統一）** — 送信側付与・全種対応・マイグレーション・判定一本化 ← 土台
+2. **Mobile** — 案A トグル
+3. **Web** — 案② パネル
+
+※ 各フェーズは別々の実装計画（plan）に分割して進められる。
+
+## 9. スコープ外（今回はやらない / 将来）
+
+- タブ別の未読バッジ・通知
+- 記録カードから直接コメント / 返信する機能
+- Mobile 案B（3タブ）への拡張（※土台となる enum は今回作る）
+
+---
+
+## 10. 影響を受ける主なファイル（調査済み）
+
+### Backend（共有 Supabase）
+- `supabase/functions/parse-message-tags/index.ts` — 判定の真実。全種対応・整理
+- `supabase/migrations/20251230131753_remote_schema.sql` — `messages` スキーマ
+- `supabase/migrations/`（新規）— 既存データの `tags` 補完マイグレーション
+
+### Mobile（fit-connect-mobile）
+- `lib/features/messages/presentation/screens/message_screen.dart` — 一覧描画・トグル設置
+- `lib/features/messages/presentation/widgets/message_bubble.dart` — バブル/タグ表示
+- `lib/features/messages/presentation/widgets/chat_input.dart` — 入力欄（**一体維持**）
+- `lib/features/messages/presentation/widgets/structured_tag_form.dart` — 記録フォーム（tags 付与元）
+- `lib/features/messages/providers/messages_provider.dart` — フィルタ enum・絞り込みロジック追加
+- `lib/features/messages/models/message_model.dart` — `tags` 対応済み
+- `lib/features/workout/presentation/screens/workout_screen.dart`（56行）— ワークアウト達成送信（**tags 付与が必要**）
+
+### Web（fit-connect）
+- `src/app/(user_console)/message/page.tsx` — 一覧描画・サイドパネル設置
+- `src/components/message/MessageBubble.tsx` — 記録判定（→ `tags` 基準へ）
+- `src/components/message/RecordCard.tsx` — 記録カードUI
+- `src/components/message/recordCardParser.ts` — 記録判定（→ `tags` 基準へ寄せる）
+- `src/lib/supabase/getMessages.ts` — メッセージ取得
+- `src/app/api/messages/send/route.ts` — 送信API（→ `tags` 付与）
+- `src/types/client.ts` — `Message` 型に `tags` 追加
+
+---
+
+## 11. リスク・要確認
+
+- **マイグレーション規模が未計測** — 実装直前に本番DBで計測（DB接続情報の用意が必要。`.env` は規約で参照不可のため、`PGPASSWORD` 手動指定 or `supabase start` で対応）
+- **`sender_type`** — 記録は `client` 発のみ想定。`trainer` 発の記録が存在すると、マイグレーション/付与で `client_id` 取り違えのリスク → 計測で確認
+- **webhook と送信側付与の二重化** — 重複付与・競合が起きないよう整理（送信側を主、webhook を補完 or 廃止）
+- **リアルタイム表示** — 送信側付与にすることで webhook 待ちによる分類ブレを解消
+
+### 計測用 read-only SQL（規模確認・実装直前に実行）
+`messages` テーブルに対し、以下を確認:
+- 全件数 / `cardinality(tags)>0` の件数 / `tags` 空の件数
+- `tags` 空 かつ `content` が記録パターン（`#食事%` / `#体重%` / `#運動%` / `本日のワークアウトプラン…達成しました`）の件数 = **マイグレーション対象規模**（種類別内訳）
+- `sender_type` 別の記録件数（trainer 発の有無）
+- `metadata ? 'meal_estimation'` の件数
+
+## 12. テスト方針
+
+- 判定ロジック（`cardinality(tags) > 0`）のユニットテスト
+- マイグレーションのドライラン（対象件数の事前確認）
+- Mobile: フィルタ切替・「記録のみ時の送信で自動解除」の Widget/統合テスト → **ios-simulator-qa**
+- Web: パネル開閉・フィルタ・サマリー表示の動作確認 → **chrome-web-qa**

--- a/docs/tasks/2026-06-07-message-tags-unification-plan.md
+++ b/docs/tasks/2026-06-07-message-tags-unification-plan.md
@@ -1,0 +1,760 @@
+# tags統一（基盤フェーズ）実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** メッセージの「記録/会話」判定を `tags` カラム（`cardinality(tags) > 0`）に一本化し、送信時に `#` 付きタグを確実に付与する。webhookは補完役に降格し、既存データはマイグレーションで補完する。
+
+**Architecture:** 3つの独立サブシステムを順に実装。(A) Mobile＝tags生成を `#` 付き共通純関数へ切り出し、ワークアウト達成にもタグ付与。(B) Web＝`tags` を型・パーサ・Realtimeに取り込み、判定を「tags優先＋content後方互換」に。(C) Backend＝webhookのtags書き込みを補完役（空時のみ）に降格し records 生成も tags 起点に、既存データを backfill。共通契約は **正準タグ＝`#`付き**（`#食事:昼食` / `#体重` / `#運動:筋トレ` / `#運動:完了`）。
+
+**Tech Stack:** Flutter 3.41.9 (fvm) + Riverpod / Next.js 15 + TypeScript + Vitest / Supabase (PostgreSQL + Deno Edge Functions)
+
+**確定済み設計判断（前提）:**
+- ① 正準タグ＝`#`付きに統一
+- ② webhook＝補完役（`tags`が空の時だけ補完。records生成・FCM通知は維持）
+- ③ ワークアウト達成＝`#運動:完了` タグ付与 ＋ `exercise_records` に `other` で記録（B-1、消費カロリー取込）。`duration`/`distance`必須制約は削除済みのため追加対処不要。
+
+---
+
+## File Structure
+
+**Phase A — Mobile (`fit-connect-mobile/`)**
+- Create: `lib/features/messages/utils/message_tag_parser.dart` — tags生成の純関数（唯一の正準ロジック）
+- Create: `test/features/messages/utils/message_tag_parser_test.dart`
+- Modify: `lib/features/messages/presentation/screens/message_screen.dart` — `_parseTags`削除→共通関数へ
+- Modify: `lib/features/workout/presentation/screens/workout_screen.dart` — 達成に`tags`付与
+
+**Phase B — Web (`fit-connect/`)**
+- Modify: `src/types/client.ts` — `Message`型に`tags`追加
+- Modify: `src/components/message/recordCardParser.ts` — tags対応（tags優先＋content後方互換）
+- Create: `src/components/message/recordCardParser.test.ts`
+- Modify: `src/components/message/MessageBubble.tsx` — 呼び出しに`tags`渡す
+- Modify: `src/app/(user_console)/message/page.tsx` — DB行→Message整形4箇所に`tags`
+
+**Phase C — Backend (`supabase/`)**
+- Modify: `functions/parse-message-tags/index.ts` — tags起点の判定＋補完役化
+- Create: `migrations/20260607000000_backfill_message_tags.sql` — 既存データのtags補完
+- Modify: `fit-connect/CLAUDE.md` — 古い`messages`スキーマ記述を修正
+
+> 各Phaseは独立して実装・テスト可能。推奨実装順は A → B → C（A・Bが揃えば送受信が新形式で噛み合い、Cで旧データ・webhookを整える）。
+
+---
+
+## Phase A — Mobile
+
+### Task A1: tags生成ロジックを純関数に切り出し（`#`付き正準形）＋ テスト
+
+**Files:**
+- Create: `fit-connect-mobile/lib/features/messages/utils/message_tag_parser.dart`
+- Test: `fit-connect-mobile/test/features/messages/utils/message_tag_parser_test.dart`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`fit-connect-mobile/test/features/messages/utils/message_tag_parser_test.dart`:
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fit_connect_mobile/features/messages/utils/message_tag_parser.dart';
+
+void main() {
+  group('parseMessageTags', () {
+    test('#食事:種別が本文にあれば #付きで返す', () {
+      expect(parseMessageTags('#食事:昼食 サラダチキン'), ['#食事:昼食']);
+    });
+    test('#食事 + 朝食キーワード → #食事:朝食', () {
+      expect(parseMessageTags('#食事 朝食を食べた'), ['#食事:朝食']);
+    });
+    test('#食事 のみ（種別不明）→ #食事', () {
+      expect(parseMessageTags('#食事 なにか'), ['#食事']);
+    });
+    test('#体重 → #体重', () {
+      expect(parseMessageTags('#体重 62.4kg'), ['#体重']);
+    });
+    test('#運動 + 筋トレ → #運動:筋トレ', () {
+      expect(parseMessageTags('#運動 筋トレした'), ['#運動:筋トレ']);
+    });
+    test('#運動 + ランニング → #運動:有酸素', () {
+      expect(parseMessageTags('#運動 ランニング 30分'), ['#運動:有酸素']);
+    });
+    test('#運動 + 完了 → #運動:完了', () {
+      expect(parseMessageTags('#運動:完了 脚の日'), ['#運動:完了']);
+    });
+    test('タグ無しは null', () {
+      expect(parseMessageTags('こんにちは'), isNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd fit-connect-mobile && fvm flutter test test/features/messages/utils/message_tag_parser_test.dart`
+Expected: コンパイルエラー（`message_tag_parser.dart` が存在しない / `parseMessageTags` 未定義）
+
+- [ ] **Step 3: 実装を書く**
+
+`fit-connect-mobile/lib/features/messages/utils/message_tag_parser.dart`:
+```dart
+/// メッセージ本文から記録タグ（#付き正準形）を抽出する。
+/// 記録メッセージでなければ null を返す。
+///
+/// 正準形（#付き・1要素）:
+///   '#食事:昼食 サラダ' → ['#食事:昼食']
+///   '#食事 朝食'        → ['#食事:朝食']
+///   '#体重 62.4kg'      → ['#体重']
+///   '#運動 筋トレ'      → ['#運動:筋トレ']
+///   '#運動:完了 脚の日' → ['#運動:完了']
+List<String>? parseMessageTags(String text) {
+  if (text.contains('#食事') || text.contains('#meal')) {
+    if (text.contains('朝食') || text.contains('breakfast')) return ['#食事:朝食'];
+    if (text.contains('昼食') || text.contains('lunch')) return ['#食事:昼食'];
+    if (text.contains('夕食') || text.contains('dinner')) return ['#食事:夕食'];
+    if (text.contains('間食') || text.contains('snack')) return ['#食事:間食'];
+    return ['#食事'];
+  } else if (text.contains('#体重') || text.contains('#weight')) {
+    return ['#体重'];
+  } else if (text.contains('#運動') || text.contains('#exercise')) {
+    if (text.contains('完了')) return ['#運動:完了'];
+    if (text.contains('筋トレ')) return ['#運動:筋トレ'];
+    if (text.contains('有酸素') || text.contains('ランニング')) return ['#運動:有酸素'];
+    return ['#運動'];
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd fit-connect-mobile && fvm flutter test test/features/messages/utils/message_tag_parser_test.dart`
+Expected: All tests passed! (8 tests)
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add fit-connect-mobile/lib/features/messages/utils/message_tag_parser.dart fit-connect-mobile/test/features/messages/utils/message_tag_parser_test.dart
+git commit -m "feat(mobile): tags生成を#付き正準形の純関数として切り出し"
+```
+
+---
+
+### Task A2: message_screen を共通パーサに置き換え（`#`付き化）
+
+**Files:**
+- Modify: `fit-connect-mobile/lib/features/messages/presentation/screens/message_screen.dart`
+
+- [ ] **Step 1: import を追加**
+
+ファイル冒頭の import 群に追加:
+```dart
+import 'package:fit_connect_mobile/features/messages/utils/message_tag_parser.dart';
+```
+
+- [ ] **Step 2: 旧 `_parseTags` メソッドを削除**
+
+`/// タグを解析するプライベートメソッド` のコメント行から始まる `List<String>? _parseTags(String text) { ... }`（約L109〜L135、`return null;` と閉じ `}` まで）を**まるごと削除**する。
+
+- [ ] **Step 3: 呼び出し2箇所を共通関数に置換**
+
+`_editMessage` 内（約L141）:
+```dart
+    final newTags = parseMessageTags(newContent);
+```
+`_handleSend` 内（約L190）:
+```dart
+    final tags = parseMessageTags(text);
+```
+（`_parseTags(...)` を `parseMessageTags(...)` に変えるだけ。引数・代入先は変更しない）
+
+- [ ] **Step 4: 静的解析で検証**
+
+Run: `cd fit-connect-mobile && fvm flutter analyze lib/features/messages/presentation/screens/message_screen.dart`
+Expected: No issues found!
+（これ以降、通常メッセージの送信／編集時に `tags` が `#` 付きで保存される。`message_bubble.dart` の `_buildTag` は `#` 有無を吸収するため表示は不変）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add fit-connect-mobile/lib/features/messages/presentation/screens/message_screen.dart
+git commit -m "refactor(mobile): message_screenのタグ生成を共通parseMessageTagsに統一"
+```
+
+---
+
+### Task A3: ワークアウト達成メッセージに `#運動:完了` タグを付与
+
+**Files:**
+- Modify: `fit-connect-mobile/lib/features/workout/presentation/screens/workout_screen.dart`
+
+- [ ] **Step 1: 達成送信に `tags` を追加**
+
+`_handleSubmitCompletion` 内の `MessageRepository().sendMessage(...)`（約L61-67）を以下に変更:
+```dart
+        await MessageRepository().sendMessage(
+          senderId: clientId,
+          receiverId: trainerId,
+          senderType: 'client',
+          receiverType: 'trainer',
+          content: messageContent,
+          tags: ['#運動:完了'],
+        );
+```
+（`content` の形式は変えない＝Webの達成カード表示は従来どおり content で判定される。`tags` 追加により tags 統一フィルタで「記録」に分類され、webhookが `exercise_records` を生成する）
+
+- [ ] **Step 2: 静的解析で検証**
+
+Run: `cd fit-connect-mobile && fvm flutter analyze lib/features/workout/presentation/screens/workout_screen.dart`
+Expected: No issues found!
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add fit-connect-mobile/lib/features/workout/presentation/screens/workout_screen.dart
+git commit -m "feat(mobile): ワークアウト達成に#運動:完了タグを付与"
+```
+
+---
+
+## Phase B — Web
+
+### Task B1: `Message` 型に `tags` を追加
+
+**Files:**
+- Modify: `fit-connect/src/types/client.ts`
+
+- [ ] **Step 1: `image_urls` の直後に `tags` を追加**
+
+`Message` 型（L87-106）の `image_urls: string[]`（L95）の直後に1行追加:
+```ts
+  image_urls: string[]
+  tags?: string[] | null
+  is_edited: boolean
+```
+（Realtime payload で欠落しうるため nullable。Mobile の `List<String>?` と整合）
+
+- [ ] **Step 2: 型チェックで検証**
+
+Run: `cd fit-connect && npx tsc --noEmit`
+Expected: エラーなし（既存箇所は `tags` を未使用のため影響なし）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add fit-connect/src/types/client.ts
+git commit -m "feat(web): Message型にtagsフィールドを追加"
+```
+
+---
+
+### Task B2: `recordCardParser` を tags 対応にする ＋ テスト
+
+**Files:**
+- Modify: `fit-connect/src/components/message/recordCardParser.ts`
+- Test: `fit-connect/src/components/message/recordCardParser.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`fit-connect/src/components/message/recordCardParser.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseRecordMessage } from '@/components/message/recordCardParser'
+
+describe('parseRecordMessage — tags優先', () => {
+  it('tagsが#食事:昼食なら、contentが#始まりでなくてもmeal判定', () => {
+    const r = parseRecordMessage('サラダチキン', ['#食事:昼食'])
+    expect(r?.type).toBe('meal')
+    expect(r?.label).toBe('食事記録 ─ 昼食')
+    expect(r?.details).toEqual(['サラダチキン'])
+  })
+  it('tagsが#体重なら weight 判定（本文はdetailsに）', () => {
+    const r = parseRecordMessage('#体重 62.4kg', ['#体重'])
+    expect(r?.type).toBe('weight')
+    expect(r?.details).toEqual(['62.4kg'])
+  })
+  it('tagsが#運動:筋トレ なら exercise 判定', () => {
+    const r = parseRecordMessage('#運動:筋トレ ベンチ 30分 150kcal', ['#運動:筋トレ'])
+    expect(r?.type).toBe('exercise')
+    expect(r?.label).toBe('運動記録 ─ 筋トレ')
+  })
+  it('tagsが#運動:完了 なら achievement 判定', () => {
+    const r = parseRecordMessage('本日のワークアウトプラン「脚の日」を達成しました！', ['#運動:完了'])
+    expect(r?.type).toBe('achievement')
+  })
+})
+
+describe('parseRecordMessage — content後方互換（tags空）', () => {
+  it('#体重 を従来どおり判定', () => {
+    expect(parseRecordMessage('#体重 62.4kg')?.type).toBe('weight')
+  })
+  it('#食事:朝食 テキスト付き', () => {
+    expect(parseRecordMessage('#食事:朝食 トースト')?.label).toBe('食事記録 ─ 朝食')
+  })
+  it('ワークアウト達成のcontentパターン（#なし）', () => {
+    expect(parseRecordMessage('本日のワークアウトプラン「脚の日」を達成しました！')?.type).toBe('achievement')
+  })
+  it('通常メッセージは null', () => {
+    expect(parseRecordMessage('こんにちは')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd fit-connect && npx vitest run src/components/message/recordCardParser.test.ts`
+Expected: FAIL（現状 `parseRecordMessage` は第2引数を無視し、`'サラダチキン'` は `#` 始まりでないため `null` を返す → 最初のテストが失敗）
+
+- [ ] **Step 3: `recordCardParser.ts` を全面改修**
+
+`fit-connect/src/components/message/recordCardParser.ts` を以下の内容に置き換える（既存の判定ロジックは `parseFromContent`/`buildExerciseCard` に保持し、tags ルートを追加。DRY）:
+```ts
+export type RecordCardType = 'weight' | 'meal' | 'exercise' | 'achievement'
+
+export interface RecordCardData {
+  type: RecordCardType
+  label: string
+  details: string[]
+}
+
+/**
+ * content と tags から記録カード情報を返す。記録でなければ null。
+ *
+ * 判定方針（基盤フェーズ「tags統一」）:
+ *   1. ワークアウト達成（#なしモバイル形式）は content で判定
+ *   2. tags が非空なら、それを正準として判定（cardinality(tags) > 0 = 記録）
+ *   3. tags が空なら従来の content 先頭タグ判定にフォールバック（後方互換）
+ */
+export function parseRecordMessage(content: string, tags?: string[] | null): RecordCardData | null {
+  // --- ワークアウト達成（#なし現行モバイル形式）---
+  const workoutAchievementMatch = content.match(/^本日のワークアウトプラン「([^」]+)」を達成しました！/)
+  if (workoutAchievementMatch) {
+    const details: string[] = [`「${workoutAchievementMatch[1]}」を達成しました！`]
+    const caloriesMatch = content.match(/🔥\s*消費カロリー:\s*(\d+)\s*kcal/)
+    if (caloriesMatch) details.push(`🔥 ${caloriesMatch[1]}kcal`)
+    const feedbackMatch = content.match(/💬\s*(.+)/)
+    if (feedbackMatch) details.push(`💬 ${feedbackMatch[1].trim()}`)
+    return { type: 'achievement', label: 'ワークアウト達成！', details }
+  }
+
+  // --- tags 優先判定 ---
+  if (tags && tags.length > 0) {
+    const fromTag = parseFromTag(tags[0], content)
+    if (fromTag) return fromTag
+  }
+
+  // --- 従来の content ベース判定（tags空・後方互換）---
+  if (!content.startsWith('#')) return null
+  return parseFromContent(content)
+}
+
+/** tag（#付き正準形）から記録カードを構築。本文は content から先頭タグを除いた残り。 */
+function parseFromTag(tag: string, content: string): RecordCardData | null {
+  const m = tag.match(/^#(体重|食事|運動)(?::(.+))?$/)
+  if (!m) return null
+  const category = m[1]
+  const detail = m[2]?.trim()
+  const body = content.replace(/^#(食事|運動|体重)(?::[^\s]+)?\s*/, '').trim()
+
+  if (category === '体重') {
+    return { type: 'weight', label: '体重記録', details: body ? [body] : [] }
+  }
+  if (category === '食事') {
+    return {
+      type: 'meal',
+      label: detail ? `食事記録 ─ ${detail}` : '食事記録',
+      details: body ? [body] : [],
+    }
+  }
+  // category === '運動'
+  if (detail === '完了') {
+    const quoted = content.match(/「([^」]+)」/)
+    return {
+      type: 'achievement',
+      label: 'ワークアウト達成！',
+      details: quoted ? [`「${quoted[1]}」を達成しました！`] : (body ? [body] : []),
+    }
+  }
+  return buildExerciseCard(detail ?? '', body)
+}
+
+/** 従来の content 先頭タグ判定（既存ロジックを保持）。 */
+function parseFromContent(content: string): RecordCardData | null {
+  const weightMatch = content.match(/^#体重\s+(.+)$/)
+  if (weightMatch) {
+    return { type: 'weight', label: '体重記録', details: [weightMatch[1].trim()] }
+  }
+  const mealMatch = content.match(/^#食事:([^\s]+)\s+(.+)$/)
+  if (mealMatch) {
+    return { type: 'meal', label: `食事記録 ─ ${mealMatch[1].trim()}`, details: [mealMatch[2].trim()] }
+  }
+  const mealOnlyMatch = content.match(/^#食事:([^\s]+)$/)
+  if (mealOnlyMatch) {
+    return { type: 'meal', label: `食事記録 ─ ${mealOnlyMatch[1].trim()}`, details: [] }
+  }
+  const achievementMatch = content.match(/^#運動:完了\s+(.+)$/)
+  if (achievementMatch) {
+    const text = achievementMatch[1].trim()
+    const quotedMatch = text.match(/「([^」]+)」/)
+    return {
+      type: 'achievement',
+      label: 'ワークアウト達成！',
+      details: quotedMatch ? [`「${quotedMatch[1]}」を達成しました！`] : [text],
+    }
+  }
+  const exerciseMatch = content.match(/^#運動:([^\s]+)\s+(.+)$/)
+  if (exerciseMatch) {
+    return buildExerciseCard(exerciseMatch[1].trim(), exerciseMatch[2].trim())
+  }
+  return null
+}
+
+/** 運動カードを構築（本文から duration/calories を抽出）。 */
+function buildExerciseCard(exerciseType: string, rest: string): RecordCardData {
+  const durationMatch = rest.match(/(\d+)\s*分/)
+  const caloriesMatch = rest.match(/(\d+)\s*(?:キロカロリー|kcal|cal)/i)
+  const bodyText = rest
+    .replace(/\d+\s*分/, '')
+    .replace(/\d+\s*(?:キロカロリー|kcal|cal)/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+  const details: string[] = []
+  if (bodyText) details.push(bodyText)
+  const metaParts: string[] = []
+  if (durationMatch) metaParts.push(`${durationMatch[1]}分`)
+  if (caloriesMatch) metaParts.push(`${caloriesMatch[1]}kcal`)
+  if (metaParts.length > 0) details.push(metaParts.join(' ・ '))
+  return {
+    type: 'exercise',
+    label: `運動記録 ─ ${exerciseType}`,
+    details: details.length > 0 ? details : [rest],
+  }
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd fit-connect && npx vitest run src/components/message/recordCardParser.test.ts`
+Expected: PASS（8 tests）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add fit-connect/src/components/message/recordCardParser.ts fit-connect/src/components/message/recordCardParser.test.ts
+git commit -m "feat(web): recordCardParserをtags優先判定に対応（content後方互換）"
+```
+
+---
+
+### Task B3: `MessageBubble` の呼び出しに `tags` を渡す
+
+**Files:**
+- Modify: `fit-connect/src/components/message/MessageBubble.tsx`
+
+- [ ] **Step 1: 呼び出しを更新**
+
+L46 を変更:
+```ts
+  const recordCardData = !isTrainer ? parseRecordMessage(message.content, message.tags) : null
+```
+
+- [ ] **Step 2: 型チェックで検証**
+
+Run: `cd fit-connect && npx tsc --noEmit`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add fit-connect/src/components/message/MessageBubble.tsx
+git commit -m "feat(web): MessageBubbleからtagsをparserに渡す"
+```
+
+---
+
+### Task B4: `page.tsx` のDB行→Message整形に `tags` を反映（4箇所）
+
+**Files:**
+- Modify: `fit-connect/src/app/(user_console)/message/page.tsx`
+
+- [ ] **Step 1: 楽観更新（トレーナー送信、約L109）に `tags: []` を追加**
+
+`newMsg` オブジェクトの `image_urls: imageUrls,`（L109）の直後に追加:
+```ts
+                    image_urls: imageUrls,
+                    tags: [],
+```
+（トレーナー送信は記録対象外。型整合のため空配列）
+
+- [ ] **Step 2: 初回フェッチ整形（約L304）に `tags` を追加**
+
+`image_urls: msg.image_urls || [],`（L304）の直後に追加:
+```ts
+                        image_urls: msg.image_urls || [],
+                        tags: msg.tags || [],
+```
+
+- [ ] **Step 3: Realtime INSERT（約L373）に `tags` を追加**
+
+`image_urls: msg.image_urls || [],`（L373）の直後に追加:
+```ts
+                                image_urls: msg.image_urls || [],
+                                tags: msg.tags || [],
+```
+
+- [ ] **Step 4: Realtime UPDATE（約L410-416）に `tags` 反映を追加（★最重要）**
+
+`setMessages` の `map` 内、`read_at: msg.read_at || null,`（L415）の直後に追加:
+```ts
+                                        read_at: msg.read_at || null,
+                                        tags: msg.tags ?? m.tags,
+```
+（webhookが補完するケースでも `tags` がUPDATEイベントで届く。これが無いと補完時に記録カードへ反映されない。`?? m.tags` で欠落時は既存値を保持）
+
+- [ ] **Step 5: 型チェックで検証**
+
+Run: `cd fit-connect && npx tsc --noEmit`
+Expected: エラーなし
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add "fit-connect/src/app/(user_console)/message/page.tsx"
+git commit -m "feat(web): メッセージ整形4箇所にtagsを反映（Realtime UPDATE含む）"
+```
+
+---
+
+## Phase C — Backend
+
+### Task C1: webhook を「tags起点判定 ＋ 補完役」に改修
+
+**Files:**
+- Modify: `supabase/functions/parse-message-tags/index.ts`
+
+設計: 送信側が付けた `tags` を正準とする。webhookは (1) records生成の判定を tags 起点（無ければcontent）に、(2) tags書き込みは「空の時だけ補完」に降格。createMeal/Weight/Exercise の各関数は `tagData` を受ける既存実装をそのまま再利用（達成は `detail='完了'` → `exercise_type='other'`、カロリーはnotesから抽出。制約削除済みのためカロリーのみで保存可）。
+
+- [ ] **Step 1: `parseTagFromTags` ヘルパーを追加**
+
+既存の `parseTag` 関数（L131-142）の直後に追加:
+```ts
+/**
+ * tags配列（#付き正準形）から tagData を構築する。送信側付与のtagsを正準として扱う。
+ * @example parseTagFromTags(['#運動:完了'], '本日の…達成しました！🔥 消費カロリー: 300kcal')
+ *   // => { category: '運動', detail: '完了', fullTag: '#運動:完了', remainingContent: '本日の…300kcal' }
+ */
+function parseTagFromTags(tags, content) {
+  if (!tags || tags.length === 0) return null
+  const fullTag = tags[0]
+  const m = fullTag.match(/^#(食事|運動|体重)(?::(.+))?$/)
+  if (!m) return null
+  return {
+    category: m[1],
+    detail: m[2],
+    fullTag,
+    remainingContent: (content || '').replace(fullTag, '').trim(),
+  }
+}
+```
+
+- [ ] **Step 2: メインの判定・tags書き込みを差し替え**
+
+`Deno.serve` 内の「`// 1. Parse Tag`」から `// 3. Create specific record` の前まで（現状 L46-72 付近）を以下に置き換える:
+```ts
+      // 0. Re-fetch full row (webhook payload may omit columns like tags/metadata)
+      const { data: fullRow, error: fetchErr } = await supabase
+        .from('messages')
+        .select('metadata, tags')
+        .eq('id', message.id)
+        .maybeSingle()
+      if (fetchErr) {
+        console.error('Failed to re-fetch message row:', fetchErr)
+      } else if (fullRow) {
+        message.metadata = fullRow.metadata
+        message.tags = fullRow.tags
+      }
+
+      // 1. Determine tag — 送信側付与のtagsを正準とし、無ければcontentから解析
+      const tagData = parseTagFromTags(message.tags, message.content) ?? parseTag(message.content)
+
+      if (tagData) {
+        // 2. tags が空のときだけ補完（送信側付与を主とする。空でなければ上書きしない）
+        if (!message.tags || message.tags.length === 0) {
+          const { error: updateError } = await supabase.from('messages').update({
+            tags: [tagData.fullTag]
+          }).eq('id', message.id)
+          if (updateError) {
+            console.error('Error backfilling message tags:', updateError)
+          }
+        }
+```
+（この置換後、続く `// 3. Create specific record based on category` の `const commonData = {...}` 以降は**現状のまま**。`if (tagData) {` のブロック開始は上の置換に含めたので、元の `if (tagData) {`〜再フェッチ block と重複しないよう、元の L49 `if (tagData) {` と L50-61 の旧再フェッチを削除すること）
+
+> 実装注意: 旧コードは `parseTag` → `if (tagData) {` → 再フェッチ → tags update の順。新コードは「再フェッチ → tagData判定 → if → tags補完」の順に組み替える。`createMealRecord`/`createWeightRecord`/`createExerciseRecord` の呼び出しと `commonData` は変更不要。
+
+- [ ] **Step 3: ローカルで webhook を起動して構文確認**
+
+Run: `cd /Users/hoshidayuuya/Documents/FIT-CONNECT && supabase functions serve parse-message-tags --no-verify-jwt`
+Expected: 起動エラーが出ないこと（型/構文エラーがあればここで判明）。確認後 Ctrl+C で停止。
+※ Docker未起動の場合は先に Docker Desktop を起動。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/functions/parse-message-tags/index.ts
+git commit -m "feat(backend): webhookをtags起点判定＋補完役に降格"
+```
+
+---
+
+### Task C2: 既存データの tags 補完マイグレーション
+
+**Files:**
+- Create: `supabase/migrations/20260607000000_backfill_message_tags.sql`
+
+- [ ] **Step 1: マイグレーションファイルを作成**
+
+`supabase/migrations/20260607000000_backfill_message_tags.sql`:
+```sql
+-- 既存 messages の tags を content から補完する（基盤フェーズ「tags統一」）。
+-- 対象: cardinality(tags)=0（タグ未設定）かつ content が既知の記録パターン。
+-- 正準形は '#' 付き（messages.tags コメント準拠）。
+-- 既存 *_records には一切触れない（tags カラムのみ更新）。
+-- tags のみのUPDATEは content列変更時のみ発火するwebhookトリガを誘発しないため安全。
+-- POSIX正規表現（否定先読み非対応のため !~ で代替）。content先頭一致(^)で誤検出を防止。
+
+BEGIN;
+
+-- 食事（detail あり）: '#食事:朝食 …' → '#食事:朝食'
+UPDATE "public"."messages"
+SET tags = ARRAY['#食事:' || substring(content from '^#食事:([^[:space:]]+)')]
+WHERE cardinality(tags) = 0
+  AND content ~ '^#食事:[^[:space:]]+';
+
+-- 食事（detail なし）: '^#食事' で始まり ':' が続かない → '#食事'
+UPDATE "public"."messages"
+SET tags = ARRAY['#食事']
+WHERE cardinality(tags) = 0
+  AND content ~ '^#食事'
+  AND content !~ '^#食事:';
+
+-- 体重: '^#体重' → '#体重'
+UPDATE "public"."messages"
+SET tags = ARRAY['#体重']
+WHERE cardinality(tags) = 0
+  AND content ~ '^#体重';
+
+-- 運動（detail あり）: '#運動:筋トレ …' / '#運動:完了 …' → '#運動:筋トレ' / '#運動:完了'
+UPDATE "public"."messages"
+SET tags = ARRAY['#運動:' || substring(content from '^#運動:([^[:space:]]+)')]
+WHERE cardinality(tags) = 0
+  AND content ~ '^#運動:[^[:space:]]+';
+
+-- 運動（detail なし）: '^#運動' で始まり ':' が続かない → '#運動'
+UPDATE "public"."messages"
+SET tags = ARRAY['#運動']
+WHERE cardinality(tags) = 0
+  AND content ~ '^#運動'
+  AND content !~ '^#運動:';
+
+-- ワークアウト達成（#なし現行モバイル形式）→ '#運動:完了'
+UPDATE "public"."messages"
+SET tags = ARRAY['#運動:完了']
+WHERE cardinality(tags) = 0
+  AND content LIKE '本日のワークアウトプラン「%」を達成しました！%';
+
+COMMIT;
+```
+
+- [ ] **Step 2: ローカルDBにクリーン適用して検証**
+
+Run（Docker Desktop 起動後、ルートから）:
+```bash
+cd /Users/hoshidayuuya/Documents/FIT-CONNECT && supabase start && supabase db reset
+```
+Expected: 全マイグレーションがタイムスタンプ順に適用され、`20260607000000_backfill_message_tags.sql` がエラーなく流れること（構文・冪等性の検証）。
+
+- [ ] **Step 3: 取りこぼし確認クエリ**
+
+Supabase Studio (`http://localhost:54323`) のSQLエディタ、または psql で実行:
+```sql
+SELECT id, left(content, 40) AS content_head, tags
+FROM messages
+WHERE cardinality(tags) = 0
+  AND (content LIKE '#%' OR content LIKE '本日のワークアウトプラン%');
+```
+Expected: 0行（記録パターンの取りこぼしが無いこと）。残れば WHERE 条件を調整。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260607000000_backfill_message_tags.sql
+git commit -m "feat(backend): 既存messagesのtagsをcontentから補完するマイグレーション"
+```
+
+> ⚠️ 本番反映（`supabase db push`）は**ユーザー承認後にのみ**実行。実行前に本番で件数を計測（下記）。
+
+---
+
+### Task C3: 本番反映前チェックリスト（実行はユーザー承認後）
+
+- [ ] **Step 1: 本番の移行対象規模を計測（read-only）**
+
+本番接続情報を用意し（`.env`は参照しない。`PGPASSWORD` 手動指定 or Studio）、以下を実行:
+```sql
+SELECT count(*) AS migration_targets
+FROM messages
+WHERE cardinality(tags) = 0
+  AND (content LIKE '#食事%' OR content LIKE '#体重%' OR content LIKE '#運動%'
+       OR content LIKE '本日のワークアウトプラン「%」を達成しました！%');
+SELECT sender_type, count(*) FROM messages
+WHERE cardinality(tags) > 0 OR content LIKE '#%' OR content LIKE '本日のワークアウト%'
+GROUP BY sender_type;  -- trainer発の記録が無いことを確認
+```
+
+- [ ] **Step 2: webhook をデプロイ → マイグレーションを push**
+
+```bash
+cd /Users/hoshidayuuya/Documents/FIT-CONNECT
+supabase functions deploy parse-message-tags --no-verify-jwt
+supabase db push
+```
+Expected: デプロイ成功、`20260607000000` がリモートに適用される。
+
+---
+
+### Task C4: 古いスキーマ記述の修正
+
+**Files:**
+- Modify: `fit-connect/CLAUDE.md`
+
+- [ ] **Step 1: `messages` テーブルの記述を実体に合わせる**
+
+`fit-connect/CLAUDE.md` の **messages** セクション（`message` / `timestamp` カラムと記載されている箇所）を、実スキーマに修正:
+- `message (TEXT)` → `content (TEXT)`
+- `timestamp (TIMESTAMPTZ)` → `created_at (TIMESTAMPTZ)`
+- 不足カラムを追記: `tags (TEXT[]) - 記録分類タグ（例 ["#食事:昼食"]）`, `metadata (JSONB) - meal_estimation等`, `image_urls`, `reply_to_message_id`, `read_at`, `edited_at`, `is_edited`
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add fit-connect/CLAUDE.md
+git commit -m "docs(web): messagesスキーマ記述を実体（content/created_at/tags/metadata）に修正"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage（design docの基盤フェーズ要件 → タスク対応）:**
+- 判定基準を `cardinality(tags)>0` に一本化 → B2（Web判定）/ A1（Mobile生成）/ C1（webhook判定）✓
+- 送信時にtagsを確実に付与 → A2（通常）/ A3（ワークアウト達成）✓
+- webhookを補完役に → C1 ✓
+- 全種類の記録をタグ対象（達成含む）→ A3 + C1（exercise_records生成）✓
+- 既存データのマイグレーション → C2 ✓
+- 型/モデル更新 → B1（Web型）。Mobileモデルは対応済みのため変更なし ✓
+- CLAUDE.md古い記述修正 → C4 ✓
+- ③ B-1（達成をexercise_recordsにother+カロリーで記録）→ A3 + C1（制約削除済みで保存可）✓
+
+**2. Placeholder scan:** 各コードステップに完全な実装を記載。"TBD"等なし。Backend のテストはユニット基盤が無いため `functions serve` 起動確認＋`db reset`＋検証クエリで代替（明示済み）。
+
+**3. Type/naming consistency:**
+- Mobile: `parseMessageTags(String) → List<String>?`（#付き）。A1で定義しA2/（A3は固定値）で使用 ✓
+- Web: `parseRecordMessage(content, tags?)` / `parseFromTag` / `parseFromContent` / `buildExerciseCard`。B2で定義しB3で呼び出し ✓
+- Backend: `parseTagFromTags(tags, content)` がC1の `parseTag` と同じ tagData 形 `{category, detail, fullTag, remainingContent}` を返す → 既存 `createMealRecord` 等と互換 ✓
+- 正準タグ形式 `#カテゴリ(:detail)?` が3層で一致（Mobile生成 / Web解釈 / Backend解釈 / SQL backfill）✓

--- a/fit-connect-mobile/lib/features/messages/presentation/screens/message_screen.dart
+++ b/fit-connect-mobile/lib/features/messages/presentation/screens/message_screen.dart
@@ -14,6 +14,7 @@ import 'package:lucide_icons/lucide_icons.dart';
 import 'package:intl/intl.dart';
 import 'package:fit_connect_mobile/features/schedules/providers/trainer_schedule_provider.dart';
 import 'package:fit_connect_mobile/features/subscription/providers/ai_features_enabled_provider.dart';
+import 'package:fit_connect_mobile/features/messages/utils/message_tag_parser.dart';
 
 class MessageScreen extends ConsumerStatefulWidget {
   const MessageScreen({super.key});
@@ -106,39 +107,11 @@ class _MessageScreenState extends ConsumerState<MessageScreen> {
     });
   }
 
-  /// タグを解析するプライベートメソッド
-  List<String>? _parseTags(String text) {
-    if (text.contains('#食事') || text.contains('#meal')) {
-      if (text.contains('朝食') || text.contains('breakfast')) {
-        return ['食事:朝食'];
-      } else if (text.contains('昼食') || text.contains('lunch')) {
-        return ['食事:昼食'];
-      } else if (text.contains('夕食') || text.contains('dinner')) {
-        return ['食事:夕食'];
-      } else if (text.contains('間食') || text.contains('snack')) {
-        return ['食事:間食'];
-      } else {
-        return ['食事'];
-      }
-    } else if (text.contains('#体重') || text.contains('#weight')) {
-      return ['体重'];
-    } else if (text.contains('#運動') || text.contains('#exercise')) {
-      if (text.contains('筋トレ')) {
-        return ['運動:筋トレ'];
-      } else if (text.contains('有酸素') || text.contains('ランニング')) {
-        return ['運動:有酸素'];
-      } else {
-        return ['運動'];
-      }
-    }
-    return null;
-  }
-
   Future<void> _editMessage(String newContent) async {
     if (_editingMessageId == null) return;
 
     // タグを解析
-    final newTags = _parseTags(newContent);
+    final newTags = parseMessageTags(newContent);
 
     try {
       final success =
@@ -187,7 +160,7 @@ class _MessageScreenState extends ConsumerState<MessageScreen> {
 
     // 通常送信モード
     // Parse tags from message
-    final tags = _parseTags(text);
+    final tags = parseMessageTags(text);
 
     try {
       await ref.read(paginatedMessagesProvider.notifier).sendMessage(

--- a/fit-connect-mobile/lib/features/messages/utils/message_tag_parser.dart
+++ b/fit-connect-mobile/lib/features/messages/utils/message_tag_parser.dart
@@ -1,0 +1,28 @@
+/// メッセージ本文から記録タグ（#付き正準形）を抽出する。
+/// 記録メッセージでなければ null を返す。
+///
+/// 正準形（#付き・1要素）:
+///   '#食事:昼食 サラダ' → ['#食事:昼食']
+///   '#食事 朝食'        → ['#食事:朝食']
+///   '#体重 62.4kg'      → ['#体重']
+///   '#運動 筋トレ'      → ['#運動:筋トレ']
+///   '#運動 ランニング'  → ['#運動:ランニング']
+///   '#運動:完了 脚の日' → ['#運動:完了']
+List<String>? parseMessageTags(String text) {
+  if (text.contains('#食事') || text.contains('#meal')) {
+    if (text.contains('朝食') || text.contains('breakfast')) return ['#食事:朝食'];
+    if (text.contains('昼食') || text.contains('lunch')) return ['#食事:昼食'];
+    if (text.contains('夕食') || text.contains('dinner')) return ['#食事:夕食'];
+    if (text.contains('間食') || text.contains('snack')) return ['#食事:間食'];
+    return ['#食事'];
+  } else if (text.contains('#体重') || text.contains('#weight')) {
+    return ['#体重'];
+  } else if (text.contains('#運動') || text.contains('#exercise')) {
+    if (text.contains('完了')) return ['#運動:完了'];
+    if (text.contains('筋トレ')) return ['#運動:筋トレ'];
+    if (text.contains('ランニング')) return ['#運動:ランニング'];
+    if (text.contains('有酸素')) return ['#運動:有酸素'];
+    return ['#運動'];
+  }
+  return null;
+}

--- a/fit-connect-mobile/lib/features/workout/presentation/screens/workout_screen.dart
+++ b/fit-connect-mobile/lib/features/workout/presentation/screens/workout_screen.dart
@@ -64,6 +64,7 @@ class _WorkoutScreenState extends ConsumerState<WorkoutScreen> {
           senderType: 'client',
           receiverType: 'trainer',
           content: messageContent,
+          tags: ['#運動:完了'],
         );
       } catch (e) {
         debugPrint('[WorkoutScreen] メッセージ送信エラー: $e');

--- a/fit-connect-mobile/test/features/messages/utils/message_tag_parser_test.dart
+++ b/fit-connect-mobile/test/features/messages/utils/message_tag_parser_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fit_connect_mobile/features/messages/utils/message_tag_parser.dart';
+
+void main() {
+  group('parseMessageTags', () {
+    test('#食事:種別が本文にあれば #付きで返す', () {
+      expect(parseMessageTags('#食事:昼食 サラダチキン'), ['#食事:昼食']);
+    });
+    test('#食事 + 朝食キーワード → #食事:朝食', () {
+      expect(parseMessageTags('#食事 朝食を食べた'), ['#食事:朝食']);
+    });
+    test('#食事 のみ（種別不明）→ #食事', () {
+      expect(parseMessageTags('#食事 なにか'), ['#食事']);
+    });
+    test('#体重 → #体重', () {
+      expect(parseMessageTags('#体重 62.4kg'), ['#体重']);
+    });
+    test('#運動 + 筋トレ → #運動:筋トレ', () {
+      expect(parseMessageTags('#運動 筋トレした'), ['#運動:筋トレ']);
+    });
+    test('#運動 + ランニング → #運動:ランニング', () {
+      expect(parseMessageTags('#運動 ランニング 30分'), ['#運動:ランニング']);
+    });
+    test('#運動 + 有酸素 → #運動:有酸素', () {
+      expect(parseMessageTags('#運動 有酸素 20分'), ['#運動:有酸素']);
+    });
+    test('#運動 + 完了 → #運動:完了', () {
+      expect(parseMessageTags('#運動:完了 脚の日'), ['#運動:完了']);
+    });
+    test('タグ無しは null', () {
+      expect(parseMessageTags('こんにちは'), isNull);
+    });
+  });
+}

--- a/fit-connect/CLAUDE.md
+++ b/fit-connect/CLAUDE.md
@@ -105,8 +105,16 @@ src/
 - `receiver_id` (UUID) - Trainer or client ID
 - `sender_type` (TEXT) - 'trainer' or 'client'
 - `receiver_type` (TEXT) - 'trainer' or 'client'
-- `message` (TEXT)
-- `timestamp` (TIMESTAMPTZ)
+- `content` (TEXT) - メッセージ本文（記録タグを含む）
+- `image_urls` (TEXT[]) - 画像URL配列（最大3枚）
+- `tags` (TEXT[]) - 記録分類タグ（例: ["#食事:昼食"]、空配列なら通常会話）
+- `metadata` (JSONB) - メッセージ付随メタデータ（例: meal_estimation = {foods, calories, protein_g, fat_g, carbs_g}）
+- `reply_to_message_id` (UUID) - 返信先メッセージID
+- `read_at` (TIMESTAMPTZ) - 既読日時（NULL=未読）
+- `edited_at` (TIMESTAMPTZ) - 編集日時
+- `is_edited` (BOOLEAN) - 編集済みフラグ
+- `created_at` (TIMESTAMPTZ)
+- `updated_at` (TIMESTAMPTZ)
 
 **weight_records** (client weight tracking)
 - `id` (UUID, PK)

--- a/fit-connect/src/app/(user_console)/message/page.tsx
+++ b/fit-connect/src/app/(user_console)/message/page.tsx
@@ -107,6 +107,7 @@ function MessageContent() {
                     senderType: 'trainer',
                     receiverType: 'client',
                     image_urls: imageUrls,
+                    tags: [],
                     is_edited: false,
                     edited_at: null,
                     read_at: null,
@@ -302,6 +303,7 @@ function MessageContent() {
                         senderType: msg.sender_type,
                         receiverType: msg.receiver_type,
                         image_urls: msg.image_urls || [],
+                        tags: msg.tags || [],
                         is_edited: msg.is_edited || false,
                         edited_at: msg.edited_at || null,
                         read_at: msg.read_at || null,
@@ -371,6 +373,7 @@ function MessageContent() {
                                 senderType: msg.sender_type,
                                 receiverType: msg.receiver_type,
                                 image_urls: msg.image_urls || [],
+                                tags: msg.tags || [],
                                 is_edited: msg.is_edited || false,
                                 edited_at: msg.edited_at || null,
                                 read_at: msg.read_at || null,
@@ -413,6 +416,7 @@ function MessageContent() {
                                         is_edited: msg.is_edited || false,
                                         edited_at: msg.edited_at || null,
                                         read_at: msg.read_at || null,
+                                        tags: msg.tags ?? m.tags,
                                     }
                                     : m
                             )

--- a/fit-connect/src/components/message/MessageBubble.tsx
+++ b/fit-connect/src/components/message/MessageBubble.tsx
@@ -43,7 +43,7 @@ export function MessageBubble({
 }: MessageBubbleProps) {
   const editTextareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const recordCardData = !isTrainer ? parseRecordMessage(message.content) : null
+  const recordCardData = !isTrainer ? parseRecordMessage(message.content, message.tags) : null
 
   const avatarInitial = clientName.charAt(0).toUpperCase()
 

--- a/fit-connect/src/components/message/recordCardParser.test.ts
+++ b/fit-connect/src/components/message/recordCardParser.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { parseRecordMessage } from '@/components/message/recordCardParser'
+
+describe('parseRecordMessage — tags優先', () => {
+  it('tagsが#食事:昼食なら、contentが#始まりでなくてもmeal判定', () => {
+    const r = parseRecordMessage('サラダチキン', ['#食事:昼食'])
+    expect(r?.type).toBe('meal')
+    expect(r?.label).toBe('食事記録 ─ 昼食')
+    expect(r?.details).toEqual(['サラダチキン'])
+  })
+  it('tagsが#体重なら weight 判定（本文はdetailsに）', () => {
+    const r = parseRecordMessage('#体重 62.4kg', ['#体重'])
+    expect(r?.type).toBe('weight')
+    expect(r?.details).toEqual(['62.4kg'])
+  })
+  it('tagsが#運動:筋トレ なら exercise 判定', () => {
+    const r = parseRecordMessage('#運動:筋トレ ベンチ 30分 150kcal', ['#運動:筋トレ'])
+    expect(r?.type).toBe('exercise')
+    expect(r?.label).toBe('運動記録 ─ 筋トレ')
+  })
+  it('contentが本日形式ならachievement（content-first path）', () => {
+    // content-first（workoutAchievementMatch）で達成判定。parseFromTag には到達しない
+    const r = parseRecordMessage('本日のワークアウトプラン「脚の日」を達成しました！', ['#運動:完了'])
+    expect(r?.type).toBe('achievement')
+  })
+  it('tagsが#運動:完了でcontentが本日形式でない場合もachievement判定', () => {
+    // content-first を素通りし parseFromTag の #運動:完了 branch を実際に通す
+    const r = parseRecordMessage('ジムのワークアウト完了', ['#運動:完了'])
+    expect(r?.type).toBe('achievement')
+  })
+  it('未認識タグ＋#始まりでないcontentは null（graceful fallthrough）', () => {
+    // parseFromTag が null → content 判定へフォールスルー → #始まりでないため null
+    expect(parseRecordMessage('ただのメモ', ['#栄養'])).toBeNull()
+  })
+})
+
+describe('parseRecordMessage — content後方互換（tags空）', () => {
+  it('#体重 を従来どおり判定', () => {
+    expect(parseRecordMessage('#体重 62.4kg')?.type).toBe('weight')
+  })
+  it('#食事:朝食 テキスト付き', () => {
+    expect(parseRecordMessage('#食事:朝食 トースト')?.label).toBe('食事記録 ─ 朝食')
+  })
+  it('ワークアウト達成のcontentパターン（#なし）', () => {
+    expect(parseRecordMessage('本日のワークアウトプラン「脚の日」を達成しました！')?.type).toBe('achievement')
+  })
+  it('通常メッセージは null', () => {
+    expect(parseRecordMessage('こんにちは')).toBeNull()
+  })
+})

--- a/fit-connect/src/components/message/recordCardParser.ts
+++ b/fit-connect/src/components/message/recordCardParser.ts
@@ -7,135 +7,118 @@ export interface RecordCardData {
 }
 
 /**
- * content が記録メッセージなら RecordCardData を返す。
- * そうでなければ null を返す。
+ * content と tags から記録カード情報を返す。記録でなければ null。
  *
- * 対応パターン:
- *   #体重 {value}
- *   #食事:{mealType} {description}
- *   #運動:完了 {text}
- *   #運動:{exerciseType} {rest}
- *   本日のワークアウトプラン「{title}」を達成しました！（#なし現行モバイル形式）
+ * 判定方針（基盤フェーズ「tags統一」）:
+ *   1. ワークアウト達成（#なしモバイル形式）は content で判定
+ *   2. tags が非空なら、それを正準として判定（cardinality(tags) > 0 = 記録）
+ *   3. tags が空なら従来の content 先頭タグ判定にフォールバック（後方互換）
  */
-export function parseRecordMessage(content: string): RecordCardData | null {
+export function parseRecordMessage(content: string, tags?: string[] | null): RecordCardData | null {
   // --- ワークアウト達成（#なし現行モバイル形式）---
   const workoutAchievementMatch = content.match(/^本日のワークアウトプラン「([^」]+)」を達成しました！/)
   if (workoutAchievementMatch) {
     const details: string[] = [`「${workoutAchievementMatch[1]}」を達成しました！`]
-
-    // カロリー・フィードバック行を抽出
     const caloriesMatch = content.match(/🔥\s*消費カロリー:\s*(\d+)\s*kcal/)
-    if (caloriesMatch) {
-      details.push(`🔥 ${caloriesMatch[1]}kcal`)
-    }
+    if (caloriesMatch) details.push(`🔥 ${caloriesMatch[1]}kcal`)
     const feedbackMatch = content.match(/💬\s*(.+)/)
-    if (feedbackMatch) {
-      details.push(`💬 ${feedbackMatch[1].trim()}`)
-    }
+    if (feedbackMatch) details.push(`💬 ${feedbackMatch[1].trim()}`)
+    return { type: 'achievement', label: 'ワークアウト達成！', details }
+  }
 
+  // --- tags 優先判定 ---
+  if (tags && tags.length > 0) {
+    const fromTag = parseFromTag(tags[0], content)
+    if (fromTag) return fromTag
+  }
+
+  // --- 従来の content ベース判定（tags空・後方互換）---
+  if (!content.startsWith('#')) return null
+  return parseFromContent(content)
+}
+
+/** tag（#付き正準形）から記録カードを構築。本文は content から先頭タグを除いた残り。 */
+function parseFromTag(tag: string, content: string): RecordCardData | null {
+  const m = tag.match(/^#(体重|食事|運動)(?::(.+))?$/)
+  if (!m) return null
+  const category = m[1]
+  const detail = m[2]?.trim()
+  // content がタグで始まればタグを除去、無ければ content 全体が body
+  const body = content.replace(/^#(食事|運動|体重)(?::[^\s]+)?\s*/, '').trim()
+
+  if (category === '体重') {
+    return { type: 'weight', label: '体重記録', details: body ? [body] : [] }
+  }
+  if (category === '食事') {
+    return {
+      type: 'meal',
+      label: detail ? `食事記録 ─ ${detail}` : '食事記録',
+      details: body ? [body] : [],
+    }
+  }
+  // category === '運動'
+  // 意図的な非対称: #運動:完了 は parseFromTag では本文不要（tags が記録の正準）だが、
+  // parseFromContent では本文必須（content 単体から達成内容を取り出す必要があるため）
+  if (detail === '完了') {
+    const quoted = content.match(/「([^」]+)」/)
     return {
       type: 'achievement',
       label: 'ワークアウト達成！',
-      details,
+      details: quoted ? [`「${quoted[1]}」を達成しました！`] : (body ? [body] : []),
     }
   }
+  return buildExerciseCard(detail ?? '', body)
+}
 
-  if (!content.startsWith('#')) return null
-
-  // --- 体重 ---
+/** 従来の content 先頭タグ判定（既存ロジックを保持）。 */
+function parseFromContent(content: string): RecordCardData | null {
   const weightMatch = content.match(/^#体重\s+(.+)$/)
   if (weightMatch) {
-    return {
-      type: 'weight',
-      label: '体重記録',
-      details: [weightMatch[1].trim()],
-    }
+    return { type: 'weight', label: '体重記録', details: [weightMatch[1].trim()] }
   }
-
-  // --- 食事（テキスト付き）---
   const mealMatch = content.match(/^#食事:([^\s]+)\s+(.+)$/)
   if (mealMatch) {
-    const mealType = mealMatch[1].trim()
-    const description = mealMatch[2].trim()
-    return {
-      type: 'meal',
-      label: `食事記録 ─ ${mealType}`,
-      details: [description],
-    }
+    return { type: 'meal', label: `食事記録 ─ ${mealMatch[1].trim()}`, details: [mealMatch[2].trim()] }
   }
-
-  // --- 食事（テキストなし、画像のみ）---
   const mealOnlyMatch = content.match(/^#食事:([^\s]+)$/)
   if (mealOnlyMatch) {
-    const mealType = mealOnlyMatch[1].trim()
-    return {
-      type: 'meal',
-      label: `食事記録 ─ ${mealType}`,
-      details: [],
-    }
+    return { type: 'meal', label: `食事記録 ─ ${mealOnlyMatch[1].trim()}`, details: [] }
   }
-
-  // --- 運動:完了 ---
   const achievementMatch = content.match(/^#運動:完了\s+(.+)$/)
   if (achievementMatch) {
     const text = achievementMatch[1].trim()
-    // 「〜」で囲まれたワークアウト名を抽出して整形
     const quotedMatch = text.match(/「([^」]+)」/)
-    if (quotedMatch) {
-      return {
-        type: 'achievement',
-        label: 'ワークアウト達成！',
-        details: [`「${quotedMatch[1]}」を達成しました！`],
-      }
-    }
     return {
       type: 'achievement',
       label: 'ワークアウト達成！',
-      details: [text],
+      details: quotedMatch ? [`「${quotedMatch[1]}」を達成しました！`] : [text],
     }
   }
-
-  // --- 運動:{exerciseType} ---
   const exerciseMatch = content.match(/^#運動:([^\s]+)\s+(.+)$/)
   if (exerciseMatch) {
-    const exerciseType = exerciseMatch[1].trim()
-    const rest = exerciseMatch[2].trim()
-
-    // rest をパース: "{内容}　{duration}分　{calories}キロカロリー" のような形式
-    // 数字+分 と 数字+キロカロリー を抽出し、それ以外を内容とする
-    const durationMatch = rest.match(/(\d+)\s*分/)
-    const caloriesMatch = rest.match(/(\d+)\s*(?:キロカロリー|kcal|cal)/i)
-
-    // 内容部分: duration/calories のパターンを除いた文字列
-    const bodyText = rest
-      .replace(/\d+\s*分/, '')
-      .replace(/\d+\s*(?:キロカロリー|kcal|cal)/gi, '')
-      .replace(/\s{2,}/g, ' ')
-      .trim()
-
-    const details: string[] = []
-    if (bodyText) {
-      details.push(bodyText)
-    }
-
-    const metaParts: string[] = []
-    if (durationMatch) {
-      metaParts.push(`${durationMatch[1]}分`)
-    }
-    if (caloriesMatch) {
-      metaParts.push(`${caloriesMatch[1]}kcal`)
-    }
-    if (metaParts.length > 0) {
-      details.push(metaParts.join(' ・ '))
-    }
-
-    return {
-      type: 'exercise',
-      label: `運動記録 ─ ${exerciseType}`,
-      details: details.length > 0 ? details : [rest],
-    }
+    return buildExerciseCard(exerciseMatch[1].trim(), exerciseMatch[2].trim())
   }
-
-  // # で始まるが既知のパターンに当てはまらない場合は null
   return null
+}
+
+/** 運動カードを構築（本文から duration/calories を抽出）。 */
+function buildExerciseCard(exerciseType: string, rest: string): RecordCardData {
+  const durationMatch = rest.match(/(\d+)\s*分/)
+  const caloriesMatch = rest.match(/(\d+)\s*(?:キロカロリー|kcal|cal)/i)
+  const bodyText = rest
+    .replace(/\d+\s*分/, '')
+    .replace(/\d+\s*(?:キロカロリー|kcal|cal)/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+  const details: string[] = []
+  if (bodyText) details.push(bodyText)
+  const metaParts: string[] = []
+  if (durationMatch) metaParts.push(`${durationMatch[1]}分`)
+  if (caloriesMatch) metaParts.push(`${caloriesMatch[1]}kcal`)
+  if (metaParts.length > 0) details.push(metaParts.join(' ・ '))
+  return {
+    type: 'exercise',
+    label: `運動記録 ─ ${exerciseType}`,
+    details: details.length > 0 ? details : [rest],
+  }
 }

--- a/fit-connect/src/types/client.ts
+++ b/fit-connect/src/types/client.ts
@@ -93,6 +93,7 @@ export type Message = {
   senderType: 'client' | 'trainer'
   receiverType: 'client' | 'trainer'
   image_urls: string[]
+  tags?: string[] | null
   is_edited: boolean
   edited_at: string | null
   read_at: string | null

--- a/supabase/functions/parse-message-tags/index.ts
+++ b/supabase/functions/parse-message-tags/index.ts
@@ -43,32 +43,31 @@ Deno.serve(async (req) => {
         })
       }
 
-      // 1. Parse Tag
-      const tagData = parseTag(message.content)
+      // 0. Re-fetch full row (webhook payload may omit columns like tags/metadata)
+      const { data: fullRow, error: fetchErr } = await supabase
+        .from('messages')
+        .select('metadata, tags')
+        .eq('id', message.id)
+        .maybeSingle()
+      if (fetchErr) {
+        console.error('Failed to re-fetch message row:', fetchErr)
+      } else if (fullRow) {
+        message.metadata = fullRow.metadata
+        message.tags = fullRow.tags
+      }
+
+      // 1. Determine tag — 送信側付与のtagsを正準とし、無ければcontentから解析
+      const tagData = parseTagFromTags(message.tags, message.content) ?? parseTag(message.content)
 
       if (tagData) {
-        // Webhook payload may not include all columns (Supabase webhook config can filter columns).
-        // Re-fetch the full row so we have access to metadata, tags, etc. regardless of webhook config.
-        const { data: fullRow, error: fetchErr } = await supabase
-          .from('messages')
-          .select('metadata')
-          .eq('id', message.id)
-          .maybeSingle()
-        if (fetchErr) {
-          console.error('Failed to re-fetch message row for metadata:', fetchErr)
-        } else if (fullRow) {
-          message.metadata = fullRow.metadata
-        }
-
-        // 2. Update message with normalized tags
-        const { error: updateError } = await supabase.from('messages').update({
-          tags: [tagData.fullTag]
-        }).eq('id', message.id)
-
-        if (updateError) {
-          console.error('Error updating message tags:', updateError)
-        } else if (payload.type === 'UPDATE') {
-          console.log('UPDATE: Message tags updated (this should not trigger another webhook)')
+        // 2. tags が空のときだけ補完（送信側付与を主とする。空でなければ上書きしない）
+        if (!message.tags || message.tags.length === 0) {
+          const { error: updateError } = await supabase.from('messages').update({
+            tags: [tagData.fullTag]
+          }).eq('id', message.id)
+          if (updateError) {
+            console.error('Error backfilling message tags:', updateError)
+          }
         }
 
         // 3. Create specific record based on category
@@ -138,6 +137,24 @@ function parseTag(content: string) {
     detail: match[2], // 朝食, 筋トレ etc (undefined if not present)
     fullTag: match[0].trim(),
     remainingContent: content.replace(match[0], '').trim()
+  }
+}
+
+/**
+ * tags配列（#付き正準形）から tagData を構築する。送信側付与のtagsを正準として扱う。
+ * @example parseTagFromTags(['#運動:完了'], '本日の…達成しました！🔥 消費カロリー: 300kcal')
+ *   // => { category: '運動', detail: '完了', fullTag: '#運動:完了', remainingContent: '本日の…300kcal' }
+ */
+function parseTagFromTags(tags, content) {
+  if (!tags || tags.length === 0) return null
+  const fullTag = tags[0]
+  const m = fullTag.match(/^#(食事|運動|体重)(?::(.+))?$/)
+  if (!m) return null
+  return {
+    category: m[1],
+    detail: m[2],
+    fullTag,
+    remainingContent: (content || '').replace(fullTag, '').trim(),
   }
 }
 
@@ -280,7 +297,7 @@ async function createWeightRecord(supabase, commonData, tagData) {
  * - #運動:ウォーキング → walking
  * - #運動 → other (本文から推測)
  *
- * ※ DB制約: duration または distance が必須
+ * ※ duration/distance は NULL 可（必須制約は削除済み）
  */
 async function createExerciseRecord(supabase, commonData, tagData) {
   let exerciseType = 'other'
@@ -304,8 +321,10 @@ async function createExerciseRecord(supabase, commonData, tagData) {
     }
   }
 
-  // 本文からも運動タイプを推測（タグに詳細がない場合）
-  if (exerciseType === 'other' && commonData.notes) {
+  // 本文からも運動タイプを推測（タグに詳細がない＝'#運動'単体のときだけ）
+  // detail がある場合（例: '完了'）は notes からの推測は不要かつ有害
+  // （達成メッセージの「ワークアウトプラン」が「ラン」に誤マッチする等）
+  if (exerciseType === 'other' && !tagData.detail && commonData.notes) {
     const notes = commonData.notes
     if (notes.includes('走') || notes.includes('ラン')) exerciseType = 'running'
     else if (notes.includes('歩')) exerciseType = 'walking'

--- a/supabase/migrations/20260607000000_backfill_message_tags.sql
+++ b/supabase/migrations/20260607000000_backfill_message_tags.sql
@@ -1,0 +1,60 @@
+-- 既存 messages の tags を content から補完する（基盤フェーズ「tags統一」）。
+-- 対象: cardinality(tags)=0（タグ未設定）かつ content が既知の記録パターン。
+-- 正準形は '#' 付き（messages.tags コメント準拠）。
+-- 既存 *_records には一切触れない（tags カラムのみ更新）。
+-- tags のみのUPDATEは content列変更時のみ発火するwebhookトリガを誘発しないため安全。
+-- POSIX正規表現（否定先読み非対応のため !~ で代替）。content先頭一致(^)で誤検出を防止。
+
+BEGIN;
+
+-- 食事（detail あり）: '#食事:朝食 …' → '#食事:朝食'
+UPDATE "public"."messages"
+SET tags = ARRAY['#食事:' || substring(content from '^#食事:([^[:space:]]+)')]
+WHERE cardinality(tags) = 0
+  AND content ~ '^#食事:[^[:space:]]+';
+
+-- 食事（detail なし）: 本文キーワードから種別を判定（送信側 parseMessageTags と同じ）
+UPDATE "public"."messages"
+SET tags = ARRAY[CASE
+  WHEN content ~ '朝食|breakfast' THEN '#食事:朝食'
+  WHEN content ~ '昼食|lunch'     THEN '#食事:昼食'
+  WHEN content ~ '夕食|dinner'    THEN '#食事:夕食'
+  WHEN content ~ '間食|snack'     THEN '#食事:間食'
+  ELSE '#食事'
+END]
+WHERE cardinality(tags) = 0
+  AND content ~ '^#食事'
+  AND content !~ '^#食事:';
+
+-- 体重: '^#体重' → '#体重'
+UPDATE "public"."messages"
+SET tags = ARRAY['#体重']
+WHERE cardinality(tags) = 0
+  AND content ~ '^#体重';
+
+-- 運動（detail あり）: '#運動:筋トレ …' / '#運動:完了 …' → '#運動:筋トレ' / '#運動:完了'
+UPDATE "public"."messages"
+SET tags = ARRAY['#運動:' || substring(content from '^#運動:([^[:space:]]+)')]
+WHERE cardinality(tags) = 0
+  AND content ~ '^#運動:[^[:space:]]+';
+
+-- 運動（detail なし）: 本文キーワードから種別を判定（送信側 parseMessageTags と同じ）
+UPDATE "public"."messages"
+SET tags = ARRAY[CASE
+  WHEN content ~ '完了'       THEN '#運動:完了'
+  WHEN content ~ '筋トレ'     THEN '#運動:筋トレ'
+  WHEN content ~ 'ランニング' THEN '#運動:ランニング'
+  WHEN content ~ '有酸素'     THEN '#運動:有酸素'
+  ELSE '#運動'
+END]
+WHERE cardinality(tags) = 0
+  AND content ~ '^#運動'
+  AND content !~ '^#運動:';
+
+-- ワークアウト達成（#なし現行モバイル形式）→ '#運動:完了'
+UPDATE "public"."messages"
+SET tags = ARRAY['#運動:完了']
+WHERE cardinality(tags) = 0
+  AND content LIKE '本日のワークアウトプラン「%」を達成しました！%';
+
+COMMIT;


### PR DESCRIPTION
## Summary
メッセージの「記録/会話」判定を `messages.tags`（`cardinality(tags) > 0`）に一本化する**基盤フェーズ（tags統一）**。「会話/記録をタブ・トグルで分ける」機能の土台です。

- **Mobile**: `parseMessageTags` 純関数(#付き正準形)に切り出し、`message_screen` を統一、ワークアウト達成に `#運動:完了` 付与
- **Web**: `Message` 型に `tags`、`recordCardParser` を tags優先判定(content後方互換)、`page.tsx` 整形4箇所に tags 反映(Realtime UPDATE含む)
- **Backend**: webhook を tags起点判定+補完役に降格、既存データの backfill マイグレーション

設計書・実装計画は `docs/tasks/` に同梱。

## Test Plan
- [x] Web (Vitest) 17 passed
- [x] Mobile (Flutter) tagsパーサ 9 passed
- [ ] ローカル `supabase db reset`（Docker要）でマイグレーション動作確認
- [ ] 本番反映: `supabase functions deploy parse-message-tags` ＋ `supabase db push`（**未実施・要承認**）
- [ ] 本番の移行対象件数を事前計測

🤖 Generated with [Claude Code](https://claude.com/claude-code)