### PR TITLE
feat: メッセージ画面のパネルをドラッグでリサイズ可能に（幅＋記録パネル縦）

### DIFF
--- a/fit-connect/docs/tasks/2026-06-28-message-panel-resize-design.md
+++ b/fit-connect/docs/tasks/2026-06-28-message-panel-resize-design.md
@@ -1,0 +1,122 @@
+# メッセージ画面 パネル幅ドラッグリサイズ — 設計
+
+- 日付: 2026-06-28
+- 対象: fit-connect（Trainer Web App / Next.js）
+- ブランチ: `feature/message-panel-resize`（`develop/1.0.0` から分岐）
+
+## 目的
+
+メッセージ画面（`/message`）の3カラムのうち、**左の顧客リスト幅**と**右の記録パネル幅**を、
+境界のドラッグで自由に変更できるようにする。調整した幅は localStorage に永続化し、
+リロード・再ログイン後も維持する。
+
+## 現状（調査結果）
+
+- 3カラムは `src/app/(user_console)/message/page.tsx` の return 内に直書き（専用レイアウトコンポーネントなし）
+  - 左リスト: `page.tsx:474` `<aside className="w-72 ...">`（288px 固定）
+  - 中央会話: `page.tsx:497` `flex-1`（残り可変）
+  - 右記録パネル: `RecordSidePanel.tsx:48` `<aside className="w-96 ...">`（384px 固定）
+- 右パネルの開閉は `page.tsx:63` のローカル `useState(true)`（永続化なし）
+- 幅の state 管理・localStorage 永続化・リサイズライブラリは未導入
+- レスポンシブ（ブレークポイント）対応はメッセージ画面には無し
+
+## 方針
+
+採用アプローチ: **手書きのドラッグハンドル**（汎用フック + 共通ハンドルコンポーネント）。
+`react-resizable-panels` 等の新規ライブラリは**導入しない**（開閉できる右パネルの既存ステートマシンと
+噛み合わせる改修が大きいため）。`package.json` / `package-lock.json` は変更しない。
+
+## 構成
+
+### 新規ファイル
+
+1. `src/hooks/useResizablePanel.ts`
+   - 1パネル分の「サイズ state ＋ localStorage 永続化 ＋ min/max クランプ ＋ ドラッグ／キーボード処理」を担う汎用フック（幅・高さ両対応）
+   - 入力: `{ axis: 'x' | 'y'; storageKey; defaultSize; min; max; edge: 'left' | 'right' | 'top' | 'bottom' }`
+     - `axis` は `'x'`=幅 / `'y'`=高さ。`edge` はハンドルが置かれる辺。`'right'`/`'bottom'`＝拡大方向、`'left'`/`'top'`＝縮小方向（符号反転）
+     - カーソルは軸から導出（x=`col-resize` / y=`row-resize`）、`aria-orientation` も軸から導出（x=`vertical` / y=`horizontal`）
+   - 返り値: `{ size: number; isDragging: boolean; handleProps }`（`handleProps` に `role='separator'` / `aria-*` / `tabIndex` / `onMouseDown` / `onKeyDown`）
+2. `src/components/message/ResizeHandle.tsx`
+   - 境界に置く全長の細いドラッグ用ハンドル（見た目 ＋ `handleProps` スプレッドのみ。状態は持たない）
+   - props: `{ side: 'left' | 'right' | 'top' | 'bottom'; isDragging; ariaLabel; handleProps }`（向きは `side` から導出: left/right=縦ハンドル / top/bottom=横ハンドル）
+
+### 改修ファイル
+
+3. `src/app/(user_console)/message/page.tsx`
+   - フックを2回呼ぶ（左 / 右）
+   - 左 `<aside>` の `w-72` を撤去 → `style={{ width: left.width }}` ＋ `shrink-0`
+   - 左/中央の間に `<ResizeHandle>`（常時表示）
+   - 中央/右の間に `<ResizeHandle>`（右パネルが開いている時のみ＝既存の条件付き描画ブロック内）
+   - `right.width` を `RecordSidePanel` に渡す
+4. `src/components/message/RecordSidePanel.tsx`
+   - `w-96` を撤去 → `width` prop を受けて `style={{ width }}` ＋ `shrink-0`
+
+> 右パネルの開閉ロジック（「記録を表示」ボタン・閉じる X・`useState`）は**変更しない**。
+> 右ハンドルは開いている時だけ描画。閉じている間も幅は localStorage に保持し、再表示時に復元。
+
+## データフロー
+
+1. マウント時: 幅は**デフォルト値**で初期化（サーバー描画と一致＝ハイドレーション不整合回避）。
+   `useEffect` で localStorage を読み、妥当値があれば反映（初回のみ1フレーム調整）
+2. `mousedown`: 開始 X 座標・開始幅を記録 → `window` に `mousemove`/`mouseup` を登録 →
+   `body` のカーソルを `col-resize`・テキスト選択を抑止
+3. `mousemove`: `新幅 = 開始幅 ± (現在X − 開始X)`（左 = ＋ / 右 = −）→ min/max クランプ → 幅 state 更新
+4. `mouseup`: リスナー解除・`body` スタイル復元 → **確定幅を localStorage へ保存**（ドラッグ中は書き込まない）
+
+- localStorage キー: `fc.message.leftWidth` / `fc.message.rightWidth` / `fc.message.recordSummaryHeight`
+
+## 幅の制約
+
+| パネル | デフォルト | min | max |
+|---|---|---|---|
+| 左リスト | 288px（現 w-72） | 180px | 400px |
+| 右記録パネル | 384px（現 w-96） | 320px | 480px |
+
+- 両パネルに `shrink-0` を付与し、インライン幅を厳密維持（中央 `flex-1` が残りを吸収）
+- 中央会話領域は 1280px 幅・左右最大時でも約 320px 確保される想定
+- より厳密に中央最小幅を守る動的 max はスコープ外（v1 は固定 max。必要なら拡張）
+
+## 記録パネルのサマリー↔記録ログ 縦リサイズ
+
+記録パネル（`RecordSidePanel`）内で、上部「サマリー」と下部「記録ログ」の高さ配分を、
+境界の**縦ドラッグ**で変更できる。`useResizablePanel({ axis: 'y' })` を本コンポーネント内部で完結して使用する。
+
+- フック: `useResizablePanel({ axis: 'y', storageKey: 'fc.message.recordSummaryHeight', defaultSize: 440, min: 80, max: maxSummaryHeight, edge: 'bottom' })`（`max` は固定値ではなく後述の動的値）
+- 構造: サマリーは外側 `relative`（`overflow-hidden` は付けない＝下端ハンドルの `translate-y-1/2` がクリップされるため）＋ `style={{ height }}`。内側に `h-full overflow-y-auto` のスクロール領域を置き、その中身を `min-h-full flex flex-col` の縦カラムにする。ラベルと PFC カードは `flex-shrink-0`、グラフ枠は `flex-1 min-h-[320px] relative` ＋ 内側 `absolute inset-0`（recharts `height="100%"` が flex 由来の高さでは 0 に解決するため確定高さを与える。サマリーが高い時は拡大、低い時も最低 320px を確保→スクロール）。スクロール領域の兄弟として末尾に `<ResizeHandle side="bottom">` を配置（可視下端＝サマリー/フィルタ境界に留まる）
+- フィルタ chips・記録ログ（`flex-1 overflow-y-auto`）は変更なし
+
+### サマリー上限の動的追従
+
+固定 max だとウィンドウが低い時にフィルタ/記録ログがはみ出すため、サマリー上限を**ウィンドウ高さに動的追従**させる。
+
+- `RecordSidePanel` がルート `aside` / ヘッダー / フィルタ chips に ref を持ち、`ResizeObserver(aside)` で計測
+- `max = clamp( aside.clientHeight − headerH − filterH − LOG_MIN(8), 下限 SUMMARY_MAX_FLOOR=320, 上限 SUMMARY_MAX_CAP=1000 )`
+- これを `useResizablePanel` の `max` に渡す。`max` 変化時はフック側の**再クランプ effect**（`useEffect(() => setSize((prev) => clamp(prev)), [clamp])`）が現在 size を新範囲へ収める
+- 効果: 境界を上方向にドラッグすると記録ログを約 8px の薄いピークまで畳め、サマリーを（フィルタを残したまま）利用可能高さいっぱい＝ほぼ全画面まで拡大して全表示できる。ウィンドウ/パネル幅変更時も上限が追従
+
+| パネル | デフォルト | min | max |
+|---|---|---|---|
+| サマリー高さ | 440px | 80px | 動的（利用可能高さ − 8、範囲 320〜1000） |
+
+- グラフ `WeightNutritionChart` はサマリー高さに**追従して拡大**（`fillHeight` prop ＝ `ResponsiveContainer height="100%"`、グラフ枠の `flex-1 min-h-[320px]` で最低 320px）。サマリーを下に拡大するとグラフが伸び（余白なし）、上に縮小するとグラフは 320px で固定＋サマリー内 `overflow-y-auto` でスクロール（従来の「ログ最大」状態を維持）
+- `fillHeight` は**オプトイン**。顧客詳細の `SummaryTab` は `fillHeight` 未指定＝従来どおり固定 320px のまま（無影響）
+- 画面が短い場合、サマリーを大きく取ると下部の記録ログ表示領域が小さくなり得る（記録ログは `flex-1` で残りを吸収するため最低限は確保されるが、縦ドラッグで調整可能）
+
+## エッジケース
+
+- **異常値ガード**: localStorage が NaN・範囲外・読込不可なら `try/catch` でデフォルトにフォールバック
+- **リスナー後始末**: ドラッグ途中でアンマウントされても `useEffect` の cleanup で `window` リスナーと `body` スタイルを必ず復元
+- **ハンドルの見た目**: 既存の境界線（`#E2E8F0`）に重なる約6px の当たり判定。`cursor-col-resize`、
+  ホバー / ドラッグ中だけ控えめなアクセント表示。配色・太さは実装直前に `ui-ux-pro-max` で確定し
+  CLAUDE.md のデザイントークン（角丸控えめ・原色濫用禁止・余白確保）に準拠
+
+## 動作確認（chrome-web-qa）
+
+実装後、以下を Chrome で検証:
+
+1. 左ハンドルのドラッグで左リスト幅が変わる / min・max で止まる
+2. 右ハンドルのドラッグで右パネル幅が変わる / min・max で止まる
+3. リロード後も両幅が維持される
+4. 右パネルを閉じて再表示しても幅が復元される
+5. ドラッグ中に中央会話領域が極端に潰れない
+6. ドラッグ中のテキスト選択が起きない / カーソルが `col-resize` になる

--- a/fit-connect/src/app/(user_console)/message/page.tsx
+++ b/fit-connect/src/app/(user_console)/message/page.tsx
@@ -20,6 +20,8 @@ import { ClientListItem } from '@/components/message/ClientListItem';
 import { ChatHeader } from '@/components/message/ChatHeader';
 import { MessageDateDivider } from '@/components/message/MessageDateDivider';
 import { RecordSidePanel } from '@/components/message/RecordSidePanel';
+import { ResizeHandle } from '@/components/message/ResizeHandle';
+import { useResizablePanel } from '@/hooks/useResizablePanel';
 import { getMessageById } from '@/lib/supabase/getMessageById';
 import { getMealRecords } from '@/lib/supabase/getMealRecords';
 import { getWeightRecords } from '@/lib/supabase/getWeightRecords';
@@ -65,6 +67,10 @@ function MessageContent() {
     const [summaryLoading, setSummaryLoading] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const selectedClientRef = useRef<Client | null>(null);
+
+    // パネル幅のドラッグリサイズ（localStorage 永続化）
+    const leftResize = useResizablePanel({ axis: 'x', storageKey: 'fc.message.leftWidth', defaultSize: 288, min: 180, max: 400, edge: 'right' });
+    const rightResize = useResizablePanel({ axis: 'x', storageKey: 'fc.message.rightWidth', defaultSize: 384, min: 320, max: 480, edge: 'left' });
 
     // Keep ref in sync with state for use inside Realtime callbacks
     useEffect(() => {
@@ -471,7 +477,17 @@ function MessageContent() {
         <div className="flex h-[calc(100vh-48px)] bg-[#F8FAFC] text-[#0F172A] overflow-hidden">
 
             {/* Sidebar */}
-            <aside className="w-72 bg-white border-r border-[#E2E8F0] flex flex-col">
+            <aside
+                style={{ width: leftResize.size }}
+                className="relative shrink-0 bg-white border-r border-[#E2E8F0] flex flex-col"
+            >
+                {/* 右端リサイズハンドル */}
+                <ResizeHandle
+                    side="right"
+                    isDragging={leftResize.isDragging}
+                    ariaLabel="顧客リストの幅を調整"
+                    handleProps={leftResize.handleProps}
+                />
                 <div className="px-4 py-4 border-b border-[#E2E8F0]">
                     <h2 className="text-base font-semibold text-[#0F172A]">メッセージ</h2>
                 </div>
@@ -613,6 +629,9 @@ function MessageContent() {
                     nutritionData={nutritionData}
                     targetWeight={selectedClient.target_weight ?? undefined}
                     summaryLoading={summaryLoading}
+                    width={rightResize.size}
+                    isResizing={rightResize.isDragging}
+                    resizeHandleProps={rightResize.handleProps}
                     onClose={() => setIsRecordPanelOpen(false)}
                     onImageClick={setSelectedImageUrl}
                 />

--- a/fit-connect/src/components/clients/WeightNutritionChart.tsx
+++ b/fit-connect/src/components/clients/WeightNutritionChart.tsx
@@ -23,6 +23,11 @@ interface WeightNutritionChartProps {
   data: DailyNutritionPoint[]
   targetWeight?: number
   loading?: boolean
+  /**
+   * true のとき親要素の高さに追従して伸縮する（記録パネルの可変サマリー用）。
+   * 既定 false では従来どおり固定 320px。
+   */
+  fillHeight?: boolean
 }
 
 const COLORS = {
@@ -95,9 +100,15 @@ function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
   )
 }
 
-function EmptyState() {
+function EmptyState({ fillHeight = false }: { fillHeight?: boolean }) {
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center">
+    <div
+      className={
+        fillHeight
+          ? 'h-full flex flex-col items-center justify-center text-center'
+          : 'flex flex-col items-center justify-center py-16 text-center'
+      }
+    >
       <LineChartIcon className="w-12 h-12 text-slate-400 mb-3" />
       <p className="font-semibold text-slate-900">データがありません</p>
       <p className="text-sm text-slate-600 mt-1">選択期間に記録された体重・食事がありません</p>
@@ -105,15 +116,15 @@ function EmptyState() {
   )
 }
 
-function LoadingState() {
+function LoadingState({ fillHeight = false }: { fillHeight?: boolean }) {
   return (
-    <div className="flex items-center justify-center h-[320px]">
+    <div className={fillHeight ? 'flex items-center justify-center h-full' : 'flex items-center justify-center h-[320px]'}>
       <div className="w-full h-full bg-slate-50 rounded-md animate-pulse" />
     </div>
   )
 }
 
-export function WeightNutritionChart({ data, targetWeight, loading = false }: WeightNutritionChartProps) {
+export function WeightNutritionChart({ data, targetWeight, loading = false, fillHeight = false }: WeightNutritionChartProps) {
   const reducedMotion = usePrefersReducedMotion()
 
   const chartData = useMemo<ChartRow[]>(
@@ -136,8 +147,8 @@ export function WeightNutritionChart({ data, targetWeight, loading = false }: We
     return [Math.floor(Math.min(...all) - 2), Math.ceil(Math.max(...all) + 2)]
   }, [data, targetWeight])
 
-  if (loading) return <LoadingState />
-  if (data.length === 0) return <EmptyState />
+  if (loading) return <LoadingState fillHeight={fillHeight} />
+  if (data.length === 0) return <EmptyState fillHeight={fillHeight} />
 
   const xTickFormatter = (value: string) => {
     try {
@@ -148,7 +159,7 @@ export function WeightNutritionChart({ data, targetWeight, loading = false }: We
   }
 
   return (
-    <ResponsiveContainer width="100%" height={320}>
+    <ResponsiveContainer width="100%" height={fillHeight ? '100%' : 320}>
       <ComposedChart data={chartData} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
         <CartesianGrid stroke={COLORS.grid} strokeDasharray="3 3" vertical={false} />
         <XAxis

--- a/fit-connect/src/components/message/RecordSidePanel.tsx
+++ b/fit-connect/src/components/message/RecordSidePanel.tsx
@@ -1,31 +1,36 @@
-'use client'
+"use client";
 
-import { useMemo, useState } from 'react'
-import { X, ClipboardList } from 'lucide-react'
-import type { Message } from '@/types/client'
-import type { DailyNutritionPoint } from '@/lib/nutrition/aggregate'
-import type { RecordCardType } from '@/components/message/recordCardParser'
-import { RecordCard } from '@/components/message/RecordCard'
-import { PfcBalanceCard } from '@/components/clients/PfcBalanceCard'
-import { WeightNutritionChart } from '@/components/clients/WeightNutritionChart'
-import { extractRecordLog, filterByType } from '@/components/message/recordLog'
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X, ClipboardList } from "lucide-react";
+import type { Message } from "@/types/client";
+import type { DailyNutritionPoint } from "@/lib/nutrition/aggregate";
+import type { RecordCardType } from "@/components/message/recordCardParser";
+import { RecordCard } from "@/components/message/RecordCard";
+import { PfcBalanceCard } from "@/components/clients/PfcBalanceCard";
+import { WeightNutritionChart } from "@/components/clients/WeightNutritionChart";
+import { extractRecordLog, filterByType } from "@/components/message/recordLog";
+import { ResizeHandle } from "@/components/message/ResizeHandle";
+import { useResizablePanel } from "@/hooks/useResizablePanel";
 
 interface RecordSidePanelProps {
-  messages: Message[]
-  clientId: string
-  nutritionData: DailyNutritionPoint[]
-  targetWeight?: number
-  summaryLoading?: boolean
-  onClose: () => void
-  onImageClick: (url: string) => void
+  messages: Message[];
+  clientId: string;
+  nutritionData: DailyNutritionPoint[];
+  targetWeight?: number;
+  summaryLoading?: boolean;
+  width: number;
+  isResizing: boolean;
+  resizeHandleProps: Record<string, unknown>;
+  onClose: () => void;
+  onImageClick: (url: string) => void;
 }
 
-const TYPE_TABS: { value: RecordCardType | 'all'; label: string }[] = [
-  { value: 'all', label: 'すべて' },
-  { value: 'meal', label: '食事' },
-  { value: 'weight', label: '体重' },
-  { value: 'exercise', label: '運動' },
-]
+const TYPE_TABS: { value: RecordCardType | "all"; label: string }[] = [
+  { value: "all", label: "すべて" },
+  { value: "meal", label: "食事" },
+  { value: "weight", label: "体重" },
+  { value: "exercise", label: "運動" },
+];
 
 export function RecordSidePanel({
   messages,
@@ -33,23 +38,86 @@ export function RecordSidePanel({
   nutritionData,
   targetWeight,
   summaryLoading,
+  width,
+  isResizing,
+  resizeHandleProps,
   onClose,
   onImageClick,
 }: RecordSidePanelProps) {
-  const [typeFilter, setTypeFilter] = useState<RecordCardType | 'all'>('all')
+  const [typeFilter, setTypeFilter] = useState<RecordCardType | "all">("all");
+
+  // サマリー上限をウィンドウ高さに動的追従させるための計測用 ref
+  const asideRef = useRef<HTMLElement>(null);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const filterRef = useRef<HTMLDivElement>(null);
+  // 動的 max（SSR/初期値は従来の 680）
+  const [maxSummaryHeight, setMaxSummaryHeight] = useState(680);
+
+  // 記録ログの最小ピーク / サマリー上限の上限・下限ガード
+  const LOG_MIN = 8;
+  const SUMMARY_MAX_CAP = 1000;
+  const SUMMARY_MAX_FLOOR = 320;
+
+  // サマリー↔記録ログの高さ配分（縦ドラッグ・localStorage 永続化）
+  const summaryResize = useResizablePanel({
+    axis: "y",
+    storageKey: "fc.message.recordSummaryHeight",
+    defaultSize: 440,
+    min: 80,
+    max: maxSummaryHeight,
+    edge: "bottom",
+  });
+
+  // 利用可能高さ（aside − header − filter − LOG_MIN）を max に反映。ウィンドウ/幅変更にも追従
+  useEffect(() => {
+    const aside = asideRef.current;
+    if (!aside) return;
+    const recompute = () => {
+      const headerH = headerRef.current?.offsetHeight ?? 0;
+      const filterH = filterRef.current?.offsetHeight ?? 0;
+      const available = aside.clientHeight - headerH - filterH;
+      const next = Math.min(
+        SUMMARY_MAX_CAP,
+        Math.max(SUMMARY_MAX_FLOOR, available - LOG_MIN)
+      );
+      setMaxSummaryHeight(next);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    ro.observe(aside);
+    return () => ro.disconnect();
+  }, []);
 
   const logItems = useMemo(() => {
-    const all = extractRecordLog(messages)
+    const all = extractRecordLog(messages);
     // filterByType('all') は元配列をそのまま返すため slice() で複製してから reverse（in-place 破壊防止）
-    return filterByType(all, typeFilter).slice().reverse()
-  }, [messages, typeFilter])
+    return filterByType(all, typeFilter).slice().reverse();
+  }, [messages, typeFilter]);
 
   return (
-    <aside className="w-96 bg-white border-l border-[#E2E8F0] flex flex-col h-full overflow-hidden">
+    <aside
+      ref={asideRef}
+      style={{ width }}
+      className="relative shrink-0 bg-white border-l border-[#E2E8F0] flex flex-col h-full overflow-hidden"
+    >
+      {/* 左端リサイズハンドル */}
+      <ResizeHandle
+        side="left"
+        isDragging={isResizing}
+        ariaLabel="記録パネルの幅を調整"
+        handleProps={resizeHandleProps}
+      />
+
       {/* ヘッダー */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-[#E2E8F0] flex-shrink-0">
+      <div
+        ref={headerRef}
+        className="flex items-center justify-between px-4 py-3 border-b border-[#E2E8F0] flex-shrink-0"
+      >
         <div className="flex items-center gap-2">
-          <ClipboardList className="w-4 h-4 text-[#64748B]" aria-hidden="true" />
+          <ClipboardList
+            className="w-4 h-4 text-[#64748B]"
+            aria-hidden="true"
+          />
           <span className="text-sm font-semibold text-[#0F172A]">記録</span>
         </div>
         <button
@@ -62,49 +130,71 @@ export function RecordSidePanel({
         </button>
       </div>
 
-      {/* サマリーセクション */}
-      <div className="flex-shrink-0 border-b border-[#E2E8F0]">
-        <div className="px-4 pt-4 pb-2">
-          <p className="text-xs text-[#64748B] uppercase tracking-wide font-semibold mb-3">
-            サマリー
-          </p>
+      {/* サマリーセクション（高さ可変・内部スクロール） */}
+      {/* 外側は relative のみ。overflow-hidden は付けない（下端ハンドルの translate-y-1/2 がクリップされるため） */}
+      <div
+        className="relative flex-shrink-0"
+        style={{ height: summaryResize.size }}
+      >
+        <div className="h-full overflow-y-auto border-b border-[#E2E8F0]">
+          {/* min-h-full でサマリーが高い時は満たし、低い時は内容がはみ出してスクロール */}
+          <div className="min-h-full flex flex-col px-4 pt-4 pb-2">
+            <p className="text-xs text-[#64748B] uppercase tracking-wide font-semibold mb-3 flex-shrink-0">
+              サマリー
+            </p>
 
-          {/* 体重 × 栄養トレンドグラフ */}
-          <div className="mb-4">
-            <WeightNutritionChart
-              data={nutritionData}
-              targetWeight={targetWeight}
-              loading={summaryLoading}
-            />
-          </div>
+            {/* 体重 × 栄養トレンドグラフ（flex-1 で拡大、最低 320px は確保） */}
+            {/* relative + absolute inset-0 で確定高さを与える（recharts height="100%" が flex 由来の高さでは 0 に解決するため） */}
+            <div className="flex-1 min-h-[320px] mb-4 relative">
+              <div className="absolute inset-0">
+                <WeightNutritionChart
+                  fillHeight
+                  data={nutritionData}
+                  targetWeight={targetWeight}
+                  loading={summaryLoading}
+                />
+              </div>
+            </div>
 
-          {/* PFCバランスカード */}
-          <div className="overflow-x-auto">
-            <PfcBalanceCard data={nutritionData} />
+            {/* PFCバランスカード */}
+            <div className="overflow-x-auto flex-shrink-0">
+              <PfcBalanceCard data={nutritionData} />
+            </div>
           </div>
         </div>
+
+        {/* 下端リサイズハンドル（サマリー/フィルタ境界） */}
+        <ResizeHandle
+          side="bottom"
+          isDragging={summaryResize.isDragging}
+          ariaLabel="サマリーと記録ログの高さを調整"
+          handleProps={summaryResize.handleProps}
+        />
       </div>
 
       {/* 種別フィルタ chips */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-[#E2E8F0] flex-shrink-0 flex-wrap">
+      <div
+        ref={filterRef}
+        className="flex items-center gap-2 px-4 py-3 border-b border-[#E2E8F0] flex-shrink-0 flex-wrap"
+      >
         {TYPE_TABS.map((tab) => {
-          const isActive = typeFilter === tab.value
+          const isActive = typeFilter === tab.value;
           return (
             <button
               key={tab.value}
               type="button"
               onClick={() => setTypeFilter(tab.value)}
               className={[
-                'cursor-pointer px-3 py-1 text-xs font-medium rounded-md border transition-colors duration-200',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#14B8A6]',
+                "cursor-pointer px-3 py-1 text-xs font-medium rounded-md border transition-colors duration-200",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#14B8A6]",
                 isActive
-                  ? 'bg-[#14B8A6] text-white border-[#14B8A6]'
-                  : 'bg-white text-[#64748B] border-[#E2E8F0] hover:border-[#14B8A6] hover:text-[#0F172A]',
-              ].join(' ')}
+                  ? "bg-[#14B8A6] text-white border-[#14B8A6]"
+                  : "bg-white text-[#64748B] border-[#E2E8F0] hover:border-[#14B8A6] hover:text-[#0F172A]",
+              ].join(" ")}
             >
               {tab.label}
             </button>
-          )
+          );
         })}
       </div>
 
@@ -113,8 +203,13 @@ export function RecordSidePanel({
         {logItems.length === 0 ? (
           /* Empty state */
           <div className="flex flex-col items-center justify-center h-full px-6 py-12 text-center">
-            <ClipboardList className="w-10 h-10 text-[#94A3B8] mb-3" aria-hidden="true" />
-            <p className="text-sm font-semibold text-[#0F172A]">記録がありません</p>
+            <ClipboardList
+              className="w-10 h-10 text-[#94A3B8] mb-3"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-semibold text-[#0F172A]">
+              記録がありません
+            </p>
             <p className="text-xs text-[#64748B] mt-2 leading-relaxed">
               クライアントが食事・体重・運動を記録すると、ここに表示されます
             </p>
@@ -130,11 +225,11 @@ export function RecordSidePanel({
                   onImageClick={onImageClick}
                 />
                 <p className="text-[10px] text-[#94A3B8] mt-1.5">
-                  {new Date(item.message.created_at).toLocaleString('ja-JP', {
-                    month: 'numeric',
-                    day: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
+                  {new Date(item.message.created_at).toLocaleString("ja-JP", {
+                    month: "numeric",
+                    day: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
                   })}
                 </p>
               </li>
@@ -143,5 +238,5 @@ export function RecordSidePanel({
         )}
       </div>
     </aside>
-  )
+  );
 }

--- a/fit-connect/src/components/message/ResizeHandle.tsx
+++ b/fit-connect/src/components/message/ResizeHandle.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+interface ResizeHandleProps {
+  /**
+   * ハンドルを重ねる辺。
+   * left/right=縦ハンドル（幅調整）、top/bottom=横ハンドル（高さ調整）。
+   */
+  side: 'left' | 'right' | 'top' | 'bottom'
+  /** ドラッグ中かどうか（視覚ラインの強調に使用） */
+  isDragging: boolean
+  /** スクリーンリーダー用ラベル */
+  ariaLabel: string
+  /** useResizablePanel が返す handleProps（role/aria/tabIndex/onMouseDown/onKeyDown） */
+  handleProps: Record<string, unknown>
+}
+
+/**
+ * パネル境界に絶対配置で重ねる、全長の細いドラッグ用ハンドル。
+ * 状態は持たず、見た目とイベント配線のみを担当する（親要素は relative 前提）。
+ */
+export function ResizeHandle({
+  side,
+  isDragging,
+  ariaLabel,
+  handleProps,
+}: ResizeHandleProps) {
+  const isVerticalHandle = side === 'left' || side === 'right'
+
+  return (
+    <div
+      {...handleProps}
+      aria-label={ariaLabel}
+      className={cn(
+        'absolute z-20 flex items-center justify-center group',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#14B8A6]',
+        isVerticalHandle
+          ? 'top-0 h-full w-1.5 cursor-col-resize'
+          : 'left-0 w-full h-1.5 cursor-row-resize',
+        side === 'right' && 'right-0 translate-x-1/2',
+        side === 'left' && 'left-0 -translate-x-1/2',
+        side === 'bottom' && 'bottom-0 translate-y-1/2',
+        side === 'top' && 'top-0 -translate-y-1/2'
+      )}
+    >
+      {/* 視覚ライン。平常時は透明（既存の border が #E2E8F0 を担う） */}
+      <div
+        className={cn(
+          'transition-colors duration-150 motion-reduce:transition-none',
+          isVerticalHandle ? 'h-full' : 'w-full',
+          isDragging
+            ? cn('bg-[#0F172A]', isVerticalHandle ? 'w-0.5' : 'h-0.5')
+            : cn(
+                'bg-transparent group-hover:bg-[#14B8A6]',
+                isVerticalHandle ? 'w-px' : 'h-px'
+              )
+        )}
+      />
+    </div>
+  )
+}

--- a/fit-connect/src/hooks/useResizablePanel.ts
+++ b/fit-connect/src/hooks/useResizablePanel.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type ResizeAxis = 'x' | 'y'
+type ResizeEdge = 'left' | 'right' | 'top' | 'bottom'
+
+interface UseResizablePanelOptions {
+  /** リサイズ軸。'x'=幅 / 'y'=高さ */
+  axis: ResizeAxis
+  /** localStorage に保存するキー */
+  storageKey: string
+  /** SSR/初期描画で用いる既定サイズ(px) */
+  defaultSize: number
+  /** 下限サイズ(px) */
+  min: number
+  /** 上限サイズ(px) */
+  max: number
+  /**
+   * ハンドルが置かれる辺。
+   * axis 'x': 'right'（パネル右端）はマウスを右に動かすと拡大、'left'（パネル左端）は縮小。
+   * axis 'y': 'bottom'（パネル下端）はマウスを下に動かすと拡大、'top'（パネル上端）は縮小。
+   */
+  edge: ResizeEdge
+}
+
+interface ResizeHandleProps {
+  role: 'separator'
+  'aria-orientation': 'vertical' | 'horizontal'
+  tabIndex: number
+  'aria-valuenow': number
+  'aria-valuemin': number
+  'aria-valuemax': number
+  onMouseDown: (e: React.MouseEvent) => void
+  onKeyDown: (e: React.KeyboardEvent) => void
+  // ResizeHandle / RecordSidePanel が受け取る Record<string, unknown> へそのまま渡せるようにする
+  [key: string]: unknown
+}
+
+interface UseResizablePanelResult {
+  size: number
+  isDragging: boolean
+  handleProps: ResizeHandleProps
+}
+
+const KEYBOARD_STEP = 16
+const KEYBOARD_STEP_LARGE = 48
+
+/**
+ * 1パネル分の「サイズ state ＋ localStorage 永続化 ＋ min/max クランプ
+ * ＋ マウスドラッグ ＋ キーボード操作」を担う汎用フック（幅・高さ両対応）。
+ *
+ * SSR安全のため初期サイズは defaultSize 固定で、マウント後に localStorage を反映する。
+ */
+export function useResizablePanel({
+  axis,
+  storageKey,
+  defaultSize,
+  min,
+  max,
+  edge,
+}: UseResizablePanelOptions): UseResizablePanelResult {
+  const [size, setSize] = useState(defaultSize)
+  const [isDragging, setIsDragging] = useState(false)
+
+  // ドラッグ開始時のマウス座標・サイズ
+  const startPosRef = useRef(0)
+  const startSizeRef = useRef(defaultSize)
+  // mousemove のたびに更新する「最新確定サイズ」。mouseup での保存に使う（stale closure 回避）
+  const latestSizeRef = useRef(defaultSize)
+
+  const isHorizontalAxis = axis === 'x'
+  // 開始辺（'left'/'top'）はドラッグ方向の符号を反転する
+  const isStartEdge = edge === 'left' || edge === 'top'
+  const cursorStyle = isHorizontalAxis ? 'col-resize' : 'row-resize'
+
+  const clamp = useCallback(
+    (value: number) => Math.min(max, Math.max(min, value)),
+    [min, max]
+  )
+
+  // min/max が動的に変わった時（例: ウィンドウリサイズで max が縮む）、現在 size を新しい範囲へ再クランプ
+  useEffect(() => {
+    setSize((prev) => clamp(prev))
+  }, [clamp])
+
+  const writeStorage = useCallback(
+    (value: number) => {
+      try {
+        window.localStorage.setItem(storageKey, String(value))
+      } catch {
+        // localStorage 非対応・容量超過などは握りつぶしてデフォルト挙動を維持
+      }
+    },
+    [storageKey]
+  )
+
+  // マウント後に localStorage から復元
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(storageKey)
+      if (stored !== null) {
+        const parsed = parseInt(stored, 10)
+        if (Number.isFinite(parsed)) {
+          const clamped = clamp(parsed)
+          setSize(clamped)
+          latestSizeRef.current = clamped
+        }
+      }
+    } catch {
+      // 読み取り失敗時は defaultSize を維持
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey])
+
+  // ドラッグ用 window リスナーは ref 経由で常に最新ロジックを参照しつつ、
+  // 登録/解除する関数参照は安定させる（後始末を確実に行うため）。
+  const moveHandlerRef = useRef<(e: MouseEvent) => void>(() => {})
+  const upHandlerRef = useRef<() => void>(() => {})
+
+  const detach = useCallback(() => {
+    window.removeEventListener('mousemove', moveHandlerRef.current)
+    window.removeEventListener('mouseup', upHandlerRef.current)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }, [])
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      startPosRef.current = isHorizontalAxis ? e.clientX : e.clientY
+      startSizeRef.current = size
+      latestSizeRef.current = size
+      setIsDragging(true)
+
+      const handleMove = (ev: MouseEvent) => {
+        const current = isHorizontalAxis ? ev.clientX : ev.clientY
+        const delta = current - startPosRef.current
+        const raw = isStartEdge
+          ? startSizeRef.current - delta
+          : startSizeRef.current + delta
+        const clamped = clamp(raw)
+        latestSizeRef.current = clamped
+        setSize(clamped)
+      }
+
+      const handleUp = () => {
+        window.removeEventListener('mousemove', handleMove)
+        window.removeEventListener('mouseup', handleUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        setIsDragging(false)
+        // 確定サイズのみ保存（ドラッグ中は書かない）
+        writeStorage(latestSizeRef.current)
+      }
+
+      moveHandlerRef.current = handleMove
+      upHandlerRef.current = handleUp
+      window.addEventListener('mousemove', handleMove)
+      window.addEventListener('mouseup', handleUp)
+      document.body.style.cursor = cursorStyle
+      document.body.style.userSelect = 'none'
+    },
+    [size, isHorizontalAxis, isStartEdge, cursorStyle, clamp, writeStorage]
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const positiveKey = isHorizontalAxis ? 'ArrowRight' : 'ArrowDown'
+      const negativeKey = isHorizontalAxis ? 'ArrowLeft' : 'ArrowUp'
+      if (e.key !== positiveKey && e.key !== negativeKey) return
+      e.preventDefault()
+      const step = e.shiftKey ? KEYBOARD_STEP_LARGE : KEYBOARD_STEP
+      const dir = e.key === positiveKey ? 1 : -1
+      const signed = isStartEdge ? -dir : dir
+      const next = clamp(size + signed * step)
+      latestSizeRef.current = next
+      setSize(next)
+      writeStorage(next)
+    },
+    [size, isHorizontalAxis, isStartEdge, clamp, writeStorage]
+  )
+
+  // ドラッグ途中でのアンマウントに備え、リスナー解除と body スタイル復元を保証
+  useEffect(() => {
+    return () => {
+      detach()
+    }
+  }, [detach])
+
+  return {
+    size,
+    isDragging,
+    handleProps: {
+      role: 'separator',
+      'aria-orientation': isHorizontalAxis ? 'vertical' : 'horizontal',
+      tabIndex: 0,
+      'aria-valuenow': size,
+      'aria-valuemin': min,
+      'aria-valuemax': max,
+      onMouseDown,
+      onKeyDown,
+    },
+  }
+}


### PR DESCRIPTION
## 概要
メッセージ画面（/message）のパネルを境界ドラッグでリサイズ可能に。左右カラム幅に加え、記録パネル内のサマリー↔記録ログの高さ配分も調整でき、いずれも localStorage で永続化する。

## 変更内容
### 横リサイズ（幅）
- 左の顧客リスト幅・右の記録パネル幅を境界ドラッグで調整
- 永続化キー: `fc.message.leftWidth` / `fc.message.rightWidth`（リロード後も維持）
- 左 288px(180–400) / 右 384px(320–480)

### 縦リサイズ（記録パネル内）
- サマリー↔記録ログの高さ配分を縦ドラッグで調整（`fc.message.recordSummaryHeight`）
- サマリー拡大時はトレンドグラフが追従拡大（`fillHeight`・余白なし）、記録ログは約8pxまで畳める
- サマリー上限はウィンドウ高さに動的追従（ResizeObserver）でフィルタ/記録ログのはみ出しを防止

### 実装
- 汎用フック `useResizablePanel`（軸x/y・localStorage・min/maxクランプ・マウス/キーボード・a11y `role="separator"`）
- 共通 `ResizeHandle`（4辺対応、色トークン: hover #14B8A6 / drag #0F172A / focus-visible）
- 右パネル開閉ロジック・顧客詳細 `SummaryTab` は無変更、新規依存なし

## 確認
- `tsc --noEmit` / `npm run lint` グリーン
- 実機で幅・縦リサイズ・永続化・グラフ表示を確認済み（Chrome MCP未接続のため自動QAは手動確認で代替）

🤖 Generated with [Claude Code](https://claude.com/claude-code)