### PR TITLE
fix(supabase): スキーマドリフト修復パック（フェーズ5.2）

### DIFF
--- a/supabase/Seed.sql
+++ b/supabase/Seed.sql
@@ -75,7 +75,8 @@ INSERT INTO auth.identities (
 );
 
 -- トレーナーのプロフィール
-INSERT INTO public.profiles (id, name, email) VALUES
+-- 2026-07-10 修復: profiles は 20260131000001 で trainers へ移行・DROP されたため trainers へ INSERT
+INSERT INTO public.trainers (id, name, email) VALUES
   ('11111111-1111-1111-1111-111111111111', '山田太郎', 'yamada@fitconnect.jp');
 
 -- =============================================
@@ -147,8 +148,7 @@ INSERT INTO auth.identities (
 );
 
 -- クライアントのプロフィール
-INSERT INTO public.profiles (id, name, email) VALUES
-  ('22222222-2222-2222-2222-222222222222', '佐藤花子', 'sato@test.com');
+-- 2026-07-10 修復: profiles は DROP 済み。クライアントは直後の public.clients INSERT で登録されるため不要
 
 -- =============================================
 -- 2. クライアントの登録（トレーナーに紐づけ）

--- a/supabase/migrations/20260131000001_migrate_profiles_to_trainers.sql
+++ b/supabase/migrations/20260131000001_migrate_profiles_to_trainers.sql
@@ -1,5 +1,9 @@
 -- ================================================
 -- Migration: profiles → trainers (Idempotent)
+-- 2026-07-10 空DB reset 修復のため加筆（リモート適用済み・再実行されない）:
+--   Step 2 のデータ移行を「profiles に profile_image_url / role 列が存在する場合のみ」
+--   実行するようガードを追加。空DBでは remote_schema.sql の profiles は
+--   (id, name, email) のみで空のためスキップで問題ない。
 -- ================================================
 
 -- Step 1: trainersテーブル作成（存在しない場合のみ）
@@ -17,7 +21,8 @@ CREATE TABLE IF NOT EXISTS "public"."trainers" (
 -- Step 2: データ移行（profilesが存在する場合のみ）
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'profiles') THEN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'profiles' AND column_name = 'profile_image_url')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'profiles' AND column_name = 'role') THEN
     INSERT INTO "public"."trainers" (id, name, email, profile_image_url, created_at, updated_at)
     SELECT id, COALESCE(name, ''), email, profile_image_url, NOW(), NOW()
     FROM "public"."profiles"

--- a/supabase/migrations/20260215115338_add_client_notes_select_policy.sql
+++ b/supabase/migrations/20260215115338_add_client_notes_select_policy.sql
@@ -1,6 +1,39 @@
 -- Migration: add_client_notes_select_policy
 -- Description: クライアントは自分宛てかつ共有済みのノートのみ閲覧可能にするRLSポリシーを追加
+--
+-- 2026-07-10 スキーマドリフト修復のため加筆。
+-- client_notes テーブル本体を作成する migration が欠落しており、空DBからの
+-- `supabase db reset` では本ファイルが必ず失敗していた。そのため冒頭に
+-- CREATE TABLE IF NOT EXISTS + ENABLE ROW LEVEL SECURITY を追加し、
+-- CREATE POLICY を IF NOT EXISTS ガード付き DO ブロックで包んだ。
+-- リモートDBでは本 migration は適用済みとして履歴に記録されているため再実行されない
+-- （= リモートには一切影響しない）。空DBでの db reset を通すための修復である。
+-- テーブル定義は 2026-07-10 時点のリモート実測（schema-drift-facts.md §5）に基づく。
+
+CREATE TABLE IF NOT EXISTS client_notes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id uuid NOT NULL REFERENCES clients(client_id) ON DELETE CASCADE,
+  trainer_id uuid NOT NULL REFERENCES trainers(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  content text NOT NULL DEFAULT '',
+  file_urls text[] DEFAULT '{}',
+  is_shared boolean DEFAULT false,
+  shared_at timestamptz,
+  session_number integer,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE client_notes ENABLE ROW LEVEL SECURITY;
 
 -- クライアントは自分宛てかつ共有済みのノートのみ閲覧可能
-CREATE POLICY "clients_select_shared_notes" ON client_notes
-  FOR SELECT USING (is_shared = true AND client_id = auth.uid());
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'client_notes' AND policyname = 'clients_select_shared_notes'
+  ) THEN
+    CREATE POLICY "clients_select_shared_notes" ON client_notes
+      FOR SELECT USING (is_shared = true AND client_id = auth.uid());
+  END IF;
+END $$;

--- a/supabase/migrations/20260710010000_repair_workout_schema_drift.sql
+++ b/supabase/migrations/20260710010000_repair_workout_schema_drift.sql
@@ -1,0 +1,323 @@
+-- Migration: repair_workout_schema_drift
+-- 目的: リモートDBへ直接加えられ migration 管理外となっていた workout 系スキーマ
+--       （workout_plans / workout_exercises / workout_assignments / workout_assignment_exercises）
+--       を migration に追認し、空DBからの `supabase db reset` でリモートと同一形状を再現する。
+--       定義は 2026-07-10 時点のリモート実測（schema-drift-facts.md §1〜4）に基づく。
+--
+-- リモートには no-op である理由:
+--   - CREATE TABLE / CREATE INDEX は IF NOT EXISTS（リモートでは全て存在済み）
+--   - ADD COLUMN は IF NOT EXISTS（リモートでは全カラム存在済み）
+--   - DROP COLUMN / DROP POLICY / DROP INDEX は IF EXISTS（対象は repo 由来でリモートに存在しない）
+--   - SET NOT NULL / DROP NOT NULL はリモートの現状と同値のため no-op
+--   - 制約追加は pg_constraint の存在チェック付き DO ブロック（制約名はリモート実名）
+--   - CREATE POLICY は pg_policies の存在チェック付き DO ブロック（既存ポリシーには触れない）
+
+-- ============================================================
+-- 1. workout_plans（テーブルごと migration 欠落 → 新設）
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS workout_plans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  trainer_id uuid NOT NULL REFERENCES trainers(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text,
+  category text NOT NULL DEFAULT 'other',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  estimated_minutes integer,
+  plan_type text NOT NULL DEFAULT 'session',
+  CONSTRAINT workout_plans_plan_type_check CHECK (plan_type IN ('self_guided', 'session'))
+);
+
+ALTER TABLE workout_plans ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_workout_plans_trainer_id ON workout_plans(trainer_id);
+
+-- workout_plans のポリシー（clients_read_assigned_plans は workout_assignments.plan_id を
+-- 参照するため、後段の workout_assignments 修復後に作成する）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_plans' AND policyname = 'Trainers can manage their plans'
+  ) THEN
+    CREATE POLICY "Trainers can manage their plans"
+      ON workout_plans FOR ALL TO authenticated
+      USING (trainer_id = auth.uid())
+      WITH CHECK (trainer_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_plans' AND policyname = 'trainers_own_workout_plans'
+  ) THEN
+    CREATE POLICY "trainers_own_workout_plans"
+      ON workout_plans FOR ALL
+      USING (trainer_id = auth.uid());
+  END IF;
+END $$;
+
+-- ============================================================
+-- 2. workout_exercises（assignment紐付き → plan紐付きの雛形テーブルへ形状変換）
+-- ============================================================
+
+-- repo 由来でリモートに存在しない旧ポリシーを除去
+-- （assignment_id に依存するため、カラム削除より先に実行する必要がある）
+DROP POLICY IF EXISTS "Users can view exercises of accessible assignments" ON workout_exercises;
+DROP POLICY IF EXISTS "Users can update exercises of accessible assignments" ON workout_exercises;
+DROP POLICY IF EXISTS "Trainers can insert exercises" ON workout_exercises;
+DROP POLICY IF EXISTS "Trainers can delete exercises" ON workout_exercises;
+
+-- repo 由来でリモートに存在しない旧カラムを除去
+-- （assignment_id の FK は列削除と同時に削除される）
+ALTER TABLE workout_exercises DROP COLUMN IF EXISTS assignment_id;
+ALTER TABLE workout_exercises DROP COLUMN IF EXISTS target_sets;
+ALTER TABLE workout_exercises DROP COLUMN IF EXISTS target_reps;
+ALTER TABLE workout_exercises DROP COLUMN IF EXISTS sort_order;
+ALTER TABLE workout_exercises DROP COLUMN IF EXISTS is_completed;
+ALTER TABLE workout_exercises DROP COLUMN IF EXISTS completed_at;
+
+-- リモート実カラムを追認
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS plan_id uuid;
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS sets integer DEFAULT 3;
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS reps integer;
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS weight numeric;
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS duration_seconds integer;
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS rest_seconds integer;
+ALTER TABLE workout_exercises ADD COLUMN IF NOT EXISTS order_index integer DEFAULT 0;
+
+-- NOT NULL 化（リモートでは既に NOT NULL のため no-op）
+ALTER TABLE workout_exercises ALTER COLUMN plan_id SET NOT NULL;
+ALTER TABLE workout_exercises ALTER COLUMN sets SET NOT NULL;
+ALTER TABLE workout_exercises ALTER COLUMN order_index SET NOT NULL;
+
+-- FK（制約名はリモート実名）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_exercises_plan_id_fkey'
+      AND conrelid = 'workout_exercises'::regclass
+  ) THEN
+    ALTER TABLE workout_exercises
+      ADD CONSTRAINT workout_exercises_plan_id_fkey
+      FOREIGN KEY (plan_id) REFERENCES workout_plans(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_workout_exercises_plan_id ON workout_exercises(plan_id);
+
+-- workout_exercises のポリシー（リモート実測 2 本）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_exercises' AND policyname = 'Trainers can manage their exercises'
+  ) THEN
+    CREATE POLICY "Trainers can manage their exercises"
+      ON workout_exercises FOR ALL TO authenticated
+      USING (plan_id IN (SELECT workout_plans.id FROM workout_plans WHERE workout_plans.trainer_id = auth.uid()));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_exercises' AND policyname = 'trainers_own_workout_exercises'
+  ) THEN
+    CREATE POLICY "trainers_own_workout_exercises"
+      ON workout_exercises FOR ALL
+      USING (plan_id IN (SELECT workout_plans.id FROM workout_plans WHERE workout_plans.trainer_id = auth.uid()));
+  END IF;
+END $$;
+
+-- ============================================================
+-- 3. workout_assignments（カラム乖離の追認）
+-- ============================================================
+
+-- repo 由来でリモートに存在しない旧インデックス・旧ポリシーを除去
+DROP INDEX IF EXISTS idx_workout_assignments_client_date;
+DROP POLICY IF EXISTS "Trainers can manage own assignments" ON workout_assignments;
+
+-- repo 由来でリモートに存在しない旧カラムを除去
+ALTER TABLE workout_assignments DROP COLUMN IF EXISTS title;
+ALTER TABLE workout_assignments DROP COLUMN IF EXISTS description;
+ALTER TABLE workout_assignments DROP COLUMN IF EXISTS is_completed;
+ALTER TABLE workout_assignments DROP COLUMN IF EXISTS completed_at;
+
+-- リモート実カラムを追認（session_id / calories は既存 migration
+-- 20260221152650 / 20260223114558 が担うためここでは扱わない）
+ALTER TABLE workout_assignments ADD COLUMN IF NOT EXISTS plan_id uuid;
+ALTER TABLE workout_assignments ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending';
+ALTER TABLE workout_assignments ADD COLUMN IF NOT EXISTS trainer_note text;
+ALTER TABLE workout_assignments ADD COLUMN IF NOT EXISTS client_feedback text;
+ALTER TABLE workout_assignments ADD COLUMN IF NOT EXISTS started_at timestamptz;
+ALTER TABLE workout_assignments ADD COLUMN IF NOT EXISTS finished_at timestamptz;
+
+-- NOT NULL 化（リモートでは既に NOT NULL のため no-op）
+ALTER TABLE workout_assignments ALTER COLUMN plan_id SET NOT NULL;
+ALTER TABLE workout_assignments ALTER COLUMN status SET NOT NULL;
+
+-- リモートでは created_at / updated_at は NULL 許容（repo 定義は NOT NULL）→ 追認
+-- （リモートでは既に NULL 許容のため no-op）
+ALTER TABLE workout_assignments ALTER COLUMN created_at DROP NOT NULL;
+ALTER TABLE workout_assignments ALTER COLUMN updated_at DROP NOT NULL;
+
+-- 制約の追認（制約名はリモート実名）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_assignments_plan_id_fkey'
+      AND conrelid = 'workout_assignments'::regclass
+  ) THEN
+    ALTER TABLE workout_assignments
+      ADD CONSTRAINT workout_assignments_plan_id_fkey
+      FOREIGN KEY (plan_id) REFERENCES workout_plans(id) ON DELETE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_assignments_status_check'
+      AND conrelid = 'workout_assignments'::regclass
+  ) THEN
+    ALTER TABLE workout_assignments
+      ADD CONSTRAINT workout_assignments_status_check
+      CHECK (status IN ('pending', 'partial', 'completed', 'skipped'));
+  END IF;
+END $$;
+
+-- client_id / trainer_id FK の ON DELETE CASCADE 追認
+-- repo（20260221000000）は CASCADE なしで作成するが、リモートは CASCADE あり。
+-- リモートでは confdeltype = 'c' のため両ブロックとも no-op。
+-- 空DB再現パスでのみ CASCADE なし FK を張り替える。
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_assignments_client_id_fkey'
+      AND conrelid = 'workout_assignments'::regclass
+      AND confdeltype <> 'c'
+  ) THEN
+    ALTER TABLE workout_assignments DROP CONSTRAINT workout_assignments_client_id_fkey;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_assignments_client_id_fkey'
+      AND conrelid = 'workout_assignments'::regclass
+  ) THEN
+    ALTER TABLE workout_assignments
+      ADD CONSTRAINT workout_assignments_client_id_fkey
+      FOREIGN KEY (client_id) REFERENCES clients(client_id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_assignments_trainer_id_fkey'
+      AND conrelid = 'workout_assignments'::regclass
+      AND confdeltype <> 'c'
+  ) THEN
+    ALTER TABLE workout_assignments DROP CONSTRAINT workout_assignments_trainer_id_fkey;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_assignments_trainer_id_fkey'
+      AND conrelid = 'workout_assignments'::regclass
+  ) THEN
+    ALTER TABLE workout_assignments
+      ADD CONSTRAINT workout_assignments_trainer_id_fkey
+      FOREIGN KEY (trainer_id) REFERENCES trainers(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+-- リモート実在のインデックス3本を追認
+CREATE INDEX IF NOT EXISTS idx_workout_assignments_trainer_id ON workout_assignments(trainer_id);
+CREATE INDEX IF NOT EXISTS idx_workout_assignments_client_id ON workout_assignments(client_id);
+CREATE INDEX IF NOT EXISTS idx_workout_assignments_assigned_date ON workout_assignments(assigned_date);
+
+-- workout_assignments のポリシー
+-- （"Clients can view own assignments" / "Clients can update own assignments" は
+--   repo の 20260221000000 が同名で作成済みのため温存。ここでは触れない）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_assignments' AND policyname = 'Trainers can manage their assignments'
+  ) THEN
+    CREATE POLICY "Trainers can manage their assignments"
+      ON workout_assignments FOR ALL TO authenticated
+      USING (trainer_id = auth.uid())
+      WITH CHECK (trainer_id = auth.uid());
+  END IF;
+END $$;
+
+-- workout_plans の残りポリシー（workout_assignments.plan_id が存在するようになったため作成可能）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_plans' AND policyname = 'clients_read_assigned_plans'
+  ) THEN
+    CREATE POLICY "clients_read_assigned_plans"
+      ON workout_plans FOR SELECT
+      USING (id IN (SELECT workout_assignments.plan_id FROM workout_assignments WHERE workout_assignments.client_id = auth.uid()));
+  END IF;
+END $$;
+
+-- ============================================================
+-- 4. workout_assignment_exercises（テーブルごと migration 欠落 → 新設）
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS workout_assignment_exercises (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assignment_id uuid NOT NULL REFERENCES workout_assignments(id) ON DELETE CASCADE,
+  exercise_name text NOT NULL,
+  target_sets integer NOT NULL DEFAULT 3,
+  target_reps integer NOT NULL DEFAULT 10,
+  target_weight numeric,
+  order_index integer NOT NULL DEFAULT 0,
+  actual_sets jsonb,
+  is_completed boolean NOT NULL DEFAULT false,
+  memo text,
+  linked_exercise_id uuid REFERENCES workout_assignment_exercises(id),
+  created_at timestamptz DEFAULT now(),
+  completed_at timestamptz
+);
+
+ALTER TABLE workout_assignment_exercises ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_wae_assignment_id ON workout_assignment_exercises(assignment_id);
+
+-- workout_assignment_exercises のポリシー（リモート実測 3 本）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_assignment_exercises' AND policyname = 'Clients can view own assignment exercises'
+  ) THEN
+    CREATE POLICY "Clients can view own assignment exercises"
+      ON workout_assignment_exercises FOR SELECT
+      USING (assignment_id IN (SELECT workout_assignments.id FROM workout_assignments WHERE workout_assignments.client_id = auth.uid()));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_assignment_exercises' AND policyname = 'Clients can update own assignment exercises'
+  ) THEN
+    CREATE POLICY "Clients can update own assignment exercises"
+      ON workout_assignment_exercises FOR UPDATE
+      USING (assignment_id IN (SELECT workout_assignments.id FROM workout_assignments WHERE workout_assignments.client_id = auth.uid()));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'workout_assignment_exercises' AND policyname = 'Trainers can manage assignment exercises'
+  ) THEN
+    CREATE POLICY "Trainers can manage assignment exercises"
+      ON workout_assignment_exercises FOR ALL TO authenticated
+      USING (assignment_id IN (SELECT workout_assignments.id FROM workout_assignments WHERE workout_assignments.trainer_id = auth.uid()));
+  END IF;
+END $$;

--- a/supabase/migrations/20260710010001_repair_tickets_schema_drift.sql
+++ b/supabase/migrations/20260710010001_repair_tickets_schema_drift.sql
@@ -1,0 +1,76 @@
+-- Migration: repair_tickets_schema_drift
+-- 目的: リモートDBへ直接加えられ migration 管理外となっていた ticket_templates /
+--       ticket_subscriptions を migration に追認し、空DBからの `supabase db reset` で
+--       リモートと同一形状を再現する。
+--       定義は 2026-07-10 時点のリモート実測（schema-drift-facts.md §6）に基づく。
+--
+-- リモートには no-op である理由:
+--   - CREATE TABLE / CREATE INDEX は IF NOT EXISTS（リモートでは全て存在済み）
+--   - CREATE POLICY は pg_policies の存在チェック付き DO ブロック（既存ポリシーには触れない）
+--   - ENABLE ROW LEVEL SECURITY は冪等
+
+-- ============================================================
+-- 1. ticket_templates
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ticket_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  trainer_id uuid NOT NULL REFERENCES trainers(id) ON DELETE CASCADE,
+  template_name text NOT NULL,
+  ticket_type text NOT NULL CHECK (ticket_type IN ('personal', 'group', 'online', 'other')),
+  total_sessions integer NOT NULL CHECK (total_sessions > 0),
+  valid_months integer NOT NULL DEFAULT 1 CHECK (valid_months > 0),
+  is_recurring boolean NOT NULL DEFAULT false,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE ticket_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_ticket_templates_trainer ON ticket_templates(trainer_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'ticket_templates' AND policyname = 'Trainers can manage own templates'
+  ) THEN
+    CREATE POLICY "Trainers can manage own templates"
+      ON ticket_templates FOR ALL
+      USING (trainer_id = auth.uid())
+      WITH CHECK (trainer_id = auth.uid());
+  END IF;
+END $$;
+
+-- ============================================================
+-- 2. ticket_subscriptions
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ticket_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id uuid NOT NULL REFERENCES ticket_templates(id) ON DELETE CASCADE,
+  client_id uuid NOT NULL REFERENCES clients(client_id) ON DELETE CASCADE,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'paused', 'cancelled')),
+  start_date date NOT NULL,
+  next_issue_date date NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE (template_id, client_id)
+);
+
+ALTER TABLE ticket_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_ticket_subscriptions_status ON ticket_subscriptions(status, next_issue_date);
+CREATE INDEX IF NOT EXISTS idx_ticket_subscriptions_client ON ticket_subscriptions(client_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'ticket_subscriptions' AND policyname = 'Trainers can manage subscriptions of own clients'
+  ) THEN
+    CREATE POLICY "Trainers can manage subscriptions of own clients"
+      ON ticket_subscriptions FOR ALL
+      USING (client_id IN (SELECT clients.client_id FROM clients WHERE clients.trainer_id = auth.uid()))
+      WITH CHECK (client_id IN (SELECT clients.client_id FROM clients WHERE clients.trainer_id = auth.uid()));
+  END IF;
+END $$;

--- a/supabase/migrations/20260710010002_repair_misc_schema_drift.sql
+++ b/supabase/migrations/20260710010002_repair_misc_schema_drift.sql
@@ -1,0 +1,146 @@
+-- Migration: repair_misc_schema_drift
+-- 目的: リモートDBへ直接加えられ migration 管理外となっていた以下を追認し、
+--       空DBからの `supabase db reset` でリモートと同一形状を再現する。
+--       - clients.fcm_token / trainers.fcm_token（schema-drift-facts.md §7）
+--       - client_notes のインデックス2本 + trainer系ポリシー4本（同 §5。
+--         clients_select_shared_notes は 20260215115338 側で作成済みのため含めない）
+--       - storage バケット2件（client-notes / profile-images）+ storage.objects ポリシー6本（同 §8）
+--
+-- リモートには no-op である理由:
+--   - ADD COLUMN は IF NOT EXISTS / CREATE INDEX は IF NOT EXISTS（リモートでは存在済み）
+--   - バケットは INSERT ... ON CONFLICT (id) DO NOTHING（既存バケットを一切変更しない）
+--   - CREATE POLICY は pg_policies の存在チェック付き DO ブロック（既存ポリシーには触れない）
+
+-- ============================================================
+-- 1. fcm_token カラム（§7）
+-- ============================================================
+
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS fcm_token text;
+ALTER TABLE trainers ADD COLUMN IF NOT EXISTS fcm_token text;
+
+-- ============================================================
+-- 2. client_notes のインデックス + trainer系ポリシー（§5）
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_client_notes_client_id ON client_notes(client_id);
+CREATE INDEX IF NOT EXISTS idx_client_notes_trainer_id ON client_notes(trainer_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'client_notes' AND policyname = 'trainers_select_own_notes'
+  ) THEN
+    CREATE POLICY "trainers_select_own_notes"
+      ON client_notes FOR SELECT
+      USING (auth.uid() = trainer_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'client_notes' AND policyname = 'trainers_insert_own_notes'
+  ) THEN
+    CREATE POLICY "trainers_insert_own_notes"
+      ON client_notes FOR INSERT
+      WITH CHECK (auth.uid() = trainer_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'client_notes' AND policyname = 'trainers_update_own_notes'
+  ) THEN
+    CREATE POLICY "trainers_update_own_notes"
+      ON client_notes FOR UPDATE
+      USING (auth.uid() = trainer_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'client_notes' AND policyname = 'trainers_delete_own_notes'
+  ) THEN
+    CREATE POLICY "trainers_delete_own_notes"
+      ON client_notes FOR DELETE
+      USING (auth.uid() = trainer_id);
+  END IF;
+END $$;
+
+-- ============================================================
+-- 3. Storage バケット（§8）
+-- file_size_limit / allowed_mime_types は未確認のため id/name/public のみ指定し、
+-- ON CONFLICT (id) DO NOTHING で既存バケットには一切触れない。
+-- ============================================================
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('client-notes', 'client-notes', true)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('profile-images', 'profile-images', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- 4. storage.objects のポリシー6本（§8）
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'Profile images are publicly accessible'
+  ) THEN
+    CREATE POLICY "Profile images are publicly accessible"
+      ON storage.objects FOR SELECT
+      USING (bucket_id = 'profile-images');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'Trainers can upload own profile images'
+  ) THEN
+    CREATE POLICY "Trainers can upload own profile images"
+      ON storage.objects FOR INSERT TO authenticated
+      WITH CHECK ((bucket_id = 'profile-images') AND ((storage.foldername(name))[1] = (auth.uid())::text));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'Trainers can update own profile images'
+  ) THEN
+    CREATE POLICY "Trainers can update own profile images"
+      ON storage.objects FOR UPDATE TO authenticated
+      USING ((bucket_id = 'profile-images') AND ((storage.foldername(name))[1] = (auth.uid())::text));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'trainers_read_notes'
+  ) THEN
+    CREATE POLICY "trainers_read_notes"
+      ON storage.objects FOR SELECT
+      USING (bucket_id = 'client-notes');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'trainers_upload_notes'
+  ) THEN
+    CREATE POLICY "trainers_upload_notes"
+      ON storage.objects FOR INSERT
+      WITH CHECK ((bucket_id = 'client-notes') AND (auth.role() = 'authenticated'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'trainers_delete_notes'
+  ) THEN
+    CREATE POLICY "trainers_delete_notes"
+      ON storage.objects FOR DELETE
+      USING ((bucket_id = 'client-notes') AND (auth.role() = 'authenticated'));
+  END IF;
+END $$;


### PR DESCRIPTION
## 概要

**フェーズ5.2（セキュリティ・基盤修復）**: リモートDBへの直接変更で migration 管理外となっていたスキーマを、リモート実測に基づいて migration へ追認する。これにより **2026-01-31 以降ずっと壊れていた空DBからの `supabase db reset` が復旧**し、以後のスキーマ変更をコード管理下に戻す。

出典: `docs/tasks/2026-07-08-solution-catalog.md` カテゴリ7 施策3-A/4-A（+調査で発見した追加ドリフト）

## 発見されたドリフト（2026-07-10 リモート実測）

| 対象 | 状態 |
| --- | --- |
| `workout_plans` / `workout_assignment_exercises` | **テーブルごと migration 欠落**（Mobileワークアウト実行の本体） |
| `workout_exercises` | repo定義（assignment紐付き+is_completed）とリモート（plan紐付き雛形）が**別物** |
| `workout_assignments` | リモートは `status`('pending','partial','completed','skipped') ベース。repo由来の `title/description/is_completed/completed_at` はリモートに存在しない |
| `ticket_templates` / `ticket_subscriptions` | テーブルごと migration 欠落 |
| `client_notes` | テーブル本体が欠落（ポリシー1本のみ存在 → resetが必ず失敗する状態だった） |
| `clients.fcm_token` / `trainers.fcm_token` | カラム migration 欠落 |
| Storage `client-notes` / `profile-images` | バケット+objectsポリシー6本が管理外 |
| `20260131000001`（profiles→trainers） | リモート限定列 `profile_image_url` 参照で空DBでは必敗 |
| `Seed.sql` | DROP済み `profiles` へ INSERT（1月から壊れていた） |

## 変更内容

- **新規 migration 3本**（20260710010000〜010002）: 全文がガード付き冪等SQL。**リモートには完全 no-op**（IF NOT EXISTS / pg_policies・pg_constraint 存在チェックDOブロック / ON CONFLICT DO NOTHING）。制約名・ポリシー名・roles({public}/{authenticated}) はリモート実名を一言一句再現
- **既存 migration 修復 2本**（20260215115338 / 20260131000001）: リモートでは適用済み履歴のため再実行されず、空DB経路のみに影響
- **Seed.sql 修復**: trainers への INSERT に変更 / 冗長な profiles INSERT を削除

## 検証（実施済み）

| 項目 | 結果 |
| --- | --- |
| `supabase db reset --local`（全44 migration + seed） | ✅ 完走 |
| ローカル reset 後スキーマ vs リモート実測の突き合わせ | ✅ 列構成・NULL/デフォルト・制約名・インデックス・ポリシー名/roles・バケット4件すべて一致 |
| seed データ投入 | ✅ trainer 1 / client 1 |
| 構文検証（pglast, DOブロック内plpgsql含む） | ✅ 全パス |

軽微な既知差異1件: `workout_assignments` のクライアント向けポリシー qual がローカルは `client_id IN (SELECT ...)`、リモートは `client_id = auth.uid()`（意味的に等価、名前・roles・cmd は一致）。

## マージ後の作業

- `supabase db push` でリモートへ適用（**全文 no-op なので安全**。migration 履歴に3件記録されることが目的）

🤖 Generated with [Claude Code](https://claude.com/claude-code)