### PR TITLE
fix(supabase): cron設定のmigration化（フェーズ5.3）

### DIFF
--- a/docs/tasks/2026-07-10-cron-vault-setup.md
+++ b/docs/tasks/2026-07-10-cron-vault-setup.md
@@ -1,0 +1,90 @@
+# cron / Vault 初回セットアップ手順（ユーザー作業）
+
+**作成日**: 2026-07-10
+**対象**: プロジェクトオーナー（1回きりの手動作業）
+**関連 migration**: `supabase/migrations/20260710020000_codify_cron_jobs.sql`
+
+`auto-skip-workouts` の cron ジョブは migration で「無効(inactive)状態」で登録済みです。
+実際に動かすには、以下の **(1) Vault シークレット登録** と **(2) ジョブの有効化** が必要です。
+どちらも Supabase Dashboard の SQL Editor から実行します。
+
+---
+
+## 1. Vault シークレットの登録（2件）
+
+Supabase Dashboard → 対象プロジェクト → **SQL Editor** で以下を実行します。
+
+### 1-1. `project_url`
+
+```sql
+select vault.create_secret('https://viribpvnpgtgtmeulcmx.supabase.co', 'project_url');
+```
+
+### 1-2. `service_role_key`
+
+Dashboard → **Settings → API** から **service_role** キーの値をコピーし、
+`<service_roleキー>` 部分を置き換えて実行します。
+
+```sql
+select vault.create_secret('<service_roleキー>', 'service_role_key');
+```
+
+> ⚠️ **service_role キーは RLS を完全にバイパスする最高権限キーです。**
+> - キーの値は **絶対にリポジトリ・チャット・ドキュメントに貼らない**こと
+> - 上記 SQL は Dashboard の SQL Editor 上でのみ組み立てて実行すること
+> - 実行後、SQL Editor の履歴に残したくない場合はクエリ履歴を削除すること
+
+登録確認（値は表示されず、名前のみ確認）:
+
+```sql
+select name, created_at from vault.secrets order by created_at;
+-- 'project_url' と 'service_role_key' の2行が出ればOK
+```
+
+---
+
+## 2. `auto-skip-workouts` ジョブの有効化
+
+### ⚠️ 有効化前に必ず確認
+
+- 初回実行時、**現存25件（2026-07-10時点）の期限切れ pending 課題が一括で「スキップ」に変更されます**
+- ワークアウト繰越の不具合（リスケ時にプランが消える問題、カタログ cat2 8-A / フェーズ8.1）の
+  **修正後に有効化することを推奨**します
+- 有効化のタイミングはユーザー判断です（migration では意図的に無効状態で登録しています）
+
+### 有効化 SQL
+
+```sql
+select cron.alter_job((select jobid from cron.job where jobname='auto-skip-workouts'), active := true);
+```
+
+（再度無効化したい場合は `active := false` で同じ SQL を実行）
+
+実行スケジュール: `0 18 * * *`（UTC 18:00 = **JST 毎日 03:00**）
+
+---
+
+## 3. 動作確認方法
+
+### 登録済みジョブの一覧
+
+```sql
+select * from cron.job;
+```
+
+- `issue-recurring-tickets`（active = true、既存）と
+  `auto-skip-workouts`（有効化前は active = false）の2本が見えること
+
+### 実行履歴の確認（有効化後）
+
+```sql
+select * from cron.job_run_details order by start_time desc limit 10;
+```
+
+- `status = 'succeeded'` であること
+- `auto-skip-workouts` は pg_net 経由の HTTP POST のため、cron 側が succeeded でも
+  Edge Function 側の失敗はここに出ない。Dashboard → **Edge Functions → auto-skip-workouts → Logs**
+  も合わせて確認すること
+
+> 補足: `cron.job_run_details` の失敗を自動検知する監視ジョブは未実装
+> （フェーズ7の通知ディスパッチャ完成後に配線予定。フェーズ5.3の残タスク）。

--- a/docs/tasks/IMPLEMENTATION_TASKS.md
+++ b/docs/tasks/IMPLEMENTATION_TASKS.md
@@ -33,7 +33,7 @@
 | 2 | LLM カロリー計算 | Mobile + Supabase | 90% | 🟢 2.1〜2.5 完了（スクショ取り込み含む）/ 2.4任意項目のみバックログ |
 | 3 | オンボーディングフロー | Mobile | 0% | 🔴 未着手（実装時はカタログ cat2 3-A の設計を使用） |
 | 4 | ランディングページ | Web | 0% | 🔴 未着手（フェーズ6と連動） |
-| 5 | セキュリティ・基盤修復【緊急】 | Supabase + Web | 0% | 🔴 未着手 |
+| 5 | セキュリティ・基盤修復【緊急】 | Supabase + Web | 60% | 🟡 5.1・5.2 完了 / 5.3 cron migration 化済み・Vault 登録はユーザー作業待ち（手順書: `2026-07-10-cron-vault-setup.md`）/ 5.4 未着手 |
 | 6 | 収益化・リリース準備（Stripe/法務/アカウント削除/Apple Sign-In） | Web + Mobile + Supabase | 0% | 🔴 未着手 |
 | 7 | 通知基盤統一（device_tokens + 共通ディスパッチャ） | Supabase + Web + Mobile | 0% | 🔴 未着手 |
 | 8 | 不具合修正・顧客体験の底上げ | Mobile + Web + Supabase | 0% | 🔴 未着手 |
@@ -224,21 +224,27 @@
 
 ### タスク
 
-- [ ] **5.1 anon ポリシー DROP + LINE レガシー撤去**（cat7 1-A + 6-A、同一PR推奨・〜1日）
-  - [ ] `clients` の anon 全行 SELECT/INSERT/UPDATE ポリシー3本を DROP する migration
-  - [ ] `/liff` ページ・`/api/line/webhook`・`saveLineUser.ts` の削除、`line_user_id` 型参照の整理
-  - [ ] 適用後、anon キーで `clients` が 0 行になることを確認
-  - [ ] （後続・任意）anon への書き込み系 GRANT の REVOKE（cat7 1-B、安定稼働1〜2週間後）
-- [ ] **5.2 migration 欠落修復パック**（cat7 3-A / 4-A + 追加発見分、〜2日）
-  - [ ] `client_notes` の CREATE TABLE 復元 migration（冪等・リモート実スキーマと `db diff` で照合してから）
-  - [ ] `workout_assignments.status` 列の追認 migration + バックフィル（`is_completed` の段階廃止は別タスク）
-  - [ ] `clients.fcm_token` / `trainers.fcm_token` カラムの追認 migration（フェーズ7の device_tokens 移行の前提）
-  - [ ] `profile-images` / `client-notes` Storage バケットの作成 migration（現状コード管理外）
-  - [ ] ローカル `supabase db reset` が通ることを確認
+- [x] **5.1 anon ポリシー DROP + LINE レガシー撤去**（cat7 1-A + 6-A、同一PR推奨・〜1日）
+  - [x] `clients` の anon 全行 SELECT/INSERT/UPDATE ポリシー3本を DROP する migration
+  - [x] `/liff` ページ・`/api/line/webhook`・`saveLineUser.ts` の削除、`line_user_id` 型参照の整理
+  - [x] 適用後、anon キーで `clients` が 0 行になることを確認
+  - [x] （後続・任意）anon への書き込み系 GRANT の REVOKE（cat7 1-B、安定稼働1〜2週間後）
+  - 2026-07-10 完了（PR #62）。リモート適用済み・anon キーで `clients` が 0 行になることを検証済み
+- [x] **5.2 migration 欠落修復パック**（cat7 3-A / 4-A + 追加発見分、〜2日）
+  - [x] `client_notes` の CREATE TABLE 復元 migration（冪等・リモート実スキーマと `db diff` で照合してから）
+  - [x] `workout_assignments.status` 列の追認 migration + バックフィル（`is_completed` の段階廃止は別タスク）
+  - [x] `clients.fcm_token` / `trainers.fcm_token` カラムの追認 migration（フェーズ7の device_tokens 移行の前提）
+  - [x] `profile-images` / `client-notes` Storage バケットの作成 migration（現状コード管理外）
+  - [x] ローカル `supabase db reset` が通ることを確認
+  - 2026-07-10 完了（PR #63）。実際のドリフトは上記に加え workout 系全域（workout_plans / workout_exercises / workout_assignments / workout_assignment_exercises）・tickets 系・Seed.sql にまで及んでいたため、修復 migration 3本（`20260710010000`〜`010002`）で追認
+  - 空DBからの `supabase db reset` が通ることを確認し復旧済み
 - [ ] **5.3 pg_cron の migration 化**（cat7 5-A、〜1日）
-  - [ ] Vault に `project_url` / `service_role_key` を登録（手順を docs に記録）
-  - [ ] `auto-skip-workouts` の cron を pg_cron + pg_net で migration 化
+  - [ ] Vault に `project_url` / `service_role_key` を登録（手順を docs に記録）→ **ユーザー作業待ち**（手順書: `docs/tasks/2026-07-10-cron-vault-setup.md`）
+  - [x] `auto-skip-workouts` の cron を pg_cron + pg_net で migration 化（2026-07-10、`20260710020000_codify_cron_jobs.sql`）
   - [ ] `cron.job_run_details` の失敗監視ジョブの設計（フェーズ7の通知ディスパッチャ完成後に配線）
+  - 発見事項（2026-07-10 リモートDB実測）:
+    - `issue_recurring_tickets()` 関数 + cron ジョブ `issue-recurring-tickets` も migration 管理外だった → `20260710020000` で追認（既存ジョブには触れない存在チェック付き・リモート no-op）
+    - `auto-skip-workouts` は Edge Function がデプロイ済み ACTIVE なのに cron が存在せず、機能が休眠していた → **無効(inactive)状態で cron 登録**。有効化すると現存25件の期限切れ pending 課題が初回実行で一括スキップされるため、有効化は繰越問題（cat2 8-A）修正後にユーザー判断
 - [ ] **5.4 RLS の CI テスト基盤**（統合判断7-4、任意だが推奨）
   - [ ] anon/authenticated/他人ロールでのアクセス可否テストを `supabase/tests/` に新設（再発防止）
 

--- a/supabase/migrations/20260710020000_codify_cron_jobs.sql
+++ b/supabase/migrations/20260710020000_codify_cron_jobs.sql
@@ -1,0 +1,133 @@
+-- =============================================================================
+-- Migration: codify_cron_jobs
+-- フェーズ5.3（カタログ cat7 5-A）: リポジトリ管理外だった pg_cron 設定の migration 化
+--
+-- 目的:
+--   1. pg_cron / pg_net 拡張の有効化を migration として明文化する
+--   2. リモートDBに直接作成され migration 欠落していた `issue_recurring_tickets()`
+--      関数と cron ジョブ 'issue-recurring-tickets' を追認する
+--   3. デプロイ済み ACTIVE なのに cron が存在せず一度も動いていなかった
+--      Edge Function `auto-skip-workouts` の cron ジョブを「無効(inactive)状態」で
+--      新規登録する（有効化はユーザー判断。ファイル末尾のコメント参照）
+--
+-- リモートには no-op である理由（2026-07-10 リモートDB実測に基づく）:
+--   - CREATE EXTENSION IF NOT EXISTS: リモートは pg_cron 1.6 / pg_net 0.14 が
+--     有効済みのため no-op
+--   - issue_recurring_tickets(): CREATE OR REPLACE はリモートでも実行されるが、
+--     リモート実定義と一言一句同一のため実質 no-op
+--   - 'issue-recurring-tickets' ジョブ: jobname 存在チェック付きで作成するため、
+--     リモート（jobid=1 で存在・active）には一切触れない
+--   - 'auto-skip-workouts' ジョブ: リモートに存在しないため新規作成されるが、
+--     作成直後に inactive 化するため実行されず、動作への影響なし
+--
+-- 前提（実行時ではなくジョブ実行時に必要）:
+--   - Vault に `project_url` / `service_role_key` のシークレット登録が必要
+--     （現状 Vault は空。登録手順: docs/tasks/2026-07-10-cron-vault-setup.md）
+--   - シークレット未登録でもジョブの「登録」自体は成功する（command 文字列は
+--     ジョブ実行時に評価されるため）
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. 拡張の有効化（リモートでは既に有効なので no-op）
+-- -----------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- -----------------------------------------------------------------------------
+-- 2. issue_recurring_tickets() の追認
+--    リモートDBに直接作成されていた定期チケット発行関数。
+--    2026-07-10 リモート実測の実定義を一言一句そのまま収録
+--    （同一定義への CREATE OR REPLACE のため実質 no-op）。
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.issue_recurring_tickets()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  sub RECORD;
+  new_valid_from DATE;
+  new_valid_until DATE;
+BEGIN
+  FOR sub IN
+    SELECT ts.*, tt.template_name, tt.ticket_type, tt.total_sessions, tt.valid_months
+    FROM ticket_subscriptions ts
+    JOIN ticket_templates tt ON ts.template_id = tt.id
+    WHERE ts.status = 'active'
+      AND ts.next_issue_date <= CURRENT_DATE
+  LOOP
+    new_valid_from := sub.next_issue_date;
+    new_valid_until := sub.next_issue_date + (sub.valid_months || ' months')::INTERVAL;
+
+    -- チケット発行
+    INSERT INTO tickets (client_id, ticket_name, ticket_type, total_sessions, remaining_sessions, valid_from, valid_until)
+    VALUES (
+      sub.client_id,
+      sub.template_name,
+      sub.ticket_type,
+      sub.total_sessions,
+      sub.total_sessions,
+      new_valid_from,
+      new_valid_until
+    );
+
+    -- 次回発行日を翌月に更新
+    UPDATE ticket_subscriptions
+    SET next_issue_date = sub.next_issue_date + (sub.valid_months || ' months')::INTERVAL
+    WHERE id = sub.id;
+  END LOOP;
+END;
+$function$;
+
+-- -----------------------------------------------------------------------------
+-- 3. cron ジョブ 'issue-recurring-tickets' の追認
+--    毎日 00:00 UTC（JST 09:00）に定期チケットを発行する既存ジョブ。
+--    リモートには jobid=1・active で登録済みのため、存在しない場合のみ作成する
+--    （既存ジョブのスケジュール・状態には一切触れない）。
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'issue-recurring-tickets') THEN
+    PERFORM cron.schedule('issue-recurring-tickets', '0 0 * * *', 'SELECT issue_recurring_tickets()');
+  END IF;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 4. cron ジョブ 'auto-skip-workouts' の新規登録（無効状態）
+--    毎日 18:00 UTC（JST 03:00）に Edge Function `auto-skip-workouts` を
+--    pg_net 経由で HTTP POST 呼び出しする。URL / service_role キーは Vault の
+--    `project_url` / `service_role_key` シークレットからジョブ実行時に解決する。
+--
+--    ※ 意図的に「無効(inactive)」で登録する。有効化は繰越問題（カタログ cat2 8-A）
+--      修正後にユーザー判断とする。現存25件の期限切れ pending 課題が初回実行で
+--      一括スキップされてしまうため、修正前の有効化は行わないこと。
+--      有効化手順: docs/tasks/2026-07-10-cron-vault-setup.md
+--
+--    ※ DO ブロック自体の $$ と衝突しないよう、command 文字列は名前付き
+--      ドル引用 $cmd$ 〜 $cmd$ で記述している。
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'auto-skip-workouts') THEN
+    PERFORM cron.schedule(
+      'auto-skip-workouts',
+      '0 18 * * *',
+      $cmd$
+      SELECT net.http_post(
+        url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'project_url') || '/functions/v1/auto-skip-workouts',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key')
+        ),
+        body := '{}'::jsonb
+      );
+      $cmd$
+    );
+
+    -- 作成直後に無効化（上記コメントの通り、有効化はユーザー判断）
+    PERFORM cron.alter_job(
+      (SELECT jobid FROM cron.job WHERE jobname = 'auto-skip-workouts'),
+      active := false
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## 概要

**フェーズ5.3（セキュリティ・基盤修復）**: ダッシュボード手作業依存だった cron 設定を migration 管理下に置く。調査で判明した2つの事実に対応:

1. **`issue-recurring-tickets` cron（毎日0:00 UTC）と DB関数 `issue_recurring_tickets()` がリポジトリ管理外**だった → リモート実定義どおり追認
2. **`auto-skip-workouts` は Edge Function がデプロイ済みACTIVEなのに cron が存在せず、一度も動いていなかった**（機能が休眠状態）→ cron を新規登録

## ⚠️ auto-skip-workouts は「無効状態」で登録

現在リモートに**期限切れ（3日超）の pending 課題が25件**存在し、cron を有効にすると初回実行で一括スキップされます。「顧客が翌日に回すとプランが消える」繰越問題（カタログ cat2 8-A、フェーズ8.1）が未修正のため、**修正後にユーザー判断で有効化**する設計にしました（migration 内コメント・手順書に明記）。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `supabase/migrations/20260710020000_codify_cron_jobs.sql` | 拡張有効化（no-op）/ 関数追認（同一定義の CREATE OR REPLACE）/ 既存ジョブの存在チェック付き追認（リモートの jobid=1 には不触）/ auto-skip ジョブの新規登録→即 inactive 化 |
| `docs/tasks/2026-07-10-cron-vault-setup.md` | **要ユーザー作業**: Vault への `project_url` / `service_role_key` 登録手順（1回きり）、有効化手順、動作確認クエリ |
| `docs/tasks/IMPLEMENTATION_TASKS.md` | 5.1 / 5.2 完了・5.3 進捗を反映 |

## 検証（実施済み）

- ✅ ローカル `supabase db reset`: 全45 migration + seed 完走
- ✅ ローカル `cron.job`: `issue-recurring-tickets`（active・リモートと同状態）/ `auto-skip-workouts`（**inactive**）
- ✅ `issue_recurring_tickets()` 関数の作成確認

## マージ後の作業

1. `supabase db push`（リモートには関数の同一定義 REPLACE + inactive ジョブ追加のみ。既存ジョブ・データに影響なし）
2. **ユーザー作業**: Vault シークレット2件の登録（手順書参照。service_role キーを扱うため私は代行しません）
3. 繰越問題（フェーズ8.1）修正後、任意のタイミングで auto-skip を有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)