### PR TITLE
feat(mobile): アカウント削除機能とSign in with Apple（フェーズ6.2）

### DIFF
--- a/docs/tasks/IMPLEMENTATION_TASKS.md
+++ b/docs/tasks/IMPLEMENTATION_TASKS.md
@@ -262,7 +262,8 @@
   - [ ] 健康データのAI送信（外部API）に関する顧客側の明示同意の設計（横断レビュー1-6節）
   - [ ] トレーナー＝個人情報取扱事業者 / FIT-CONNECT＝委託先の責任分界を規約に明記
 - [ ] **6.2 アカウント削除 + Sign in with Apple**【App Store 審査ブロッカー】（横断レビュー1-1節）
-  - [ ] Mobile アプリ内からのアカウント削除（Guideline 5.1.1(v)）: auth 削除 + records/Storage 画像のカスケード削除 Edge Function
+  - [x] Mobile アプリ内からのアカウント削除（Guideline 5.1.1(v)）: auth 削除 + records/Storage 画像のカスケード削除 Edge Function
+    - Edge Function `delete-account` 新設（JWT 自前検証・削除順序: clients DELETE(子は CASCADE) → messages DELETE → Storage ベストエフォート → auth.users 削除。設定画面から2段階確認で実行）
   - [ ] Sign in with Apple 追加（Guideline 4.8。Google Sign-In があるため必須）
   - [ ] （関連）データエクスポート（個情法の開示請求対応）の方針決定
 - [ ] **6.3 Stripe SaaS 課金**（cat3 1-A、トレーナーサブスク）

--- a/fit-connect-mobile/docs/tasks/2026-07-11-apple-signin-setup.md
+++ b/fit-connect-mobile/docs/tasks/2026-07-11-apple-signin-setup.md
@@ -1,0 +1,65 @@
+# Sign in with Apple — 外部設定手順（1回きり）
+
+作成日: 2026-07-11
+対象: フェーズ6.2「Sign in with Apple」（App Store Guideline 4.8 対応）
+
+アプリ側の実装（`sign_in_with_apple` パッケージ + ネイティブ `signInWithIdToken` 方式）は完了済みです。
+以下はプロジェクトオーナーが **Apple Developer Portal** と **Supabase Dashboard** で行う1回きりの設定です。
+この設定が完了するまで、アプリの「Appleでサインイン」ボタンは認証エラーになります。
+
+---
+
+## 1. Apple Developer Portal
+
+1. [Apple Developer Portal](https://developer.apple.com/account/) にサインイン
+2. **Certificates, Identifiers & Profiles → Identifiers** を開く
+3. App ID **`com.fitconnect.fitConnectMobile`** を選択
+4. Capabilities 一覧の **「Sign In with Apple」にチェック**を入れて Save
+   - 設定は「Enable as a primary App ID」（デフォルト）のままでよい
+
+> **注意（プロビジョニングプロファイル）:**
+> App ID の capability を変更すると、既存のプロビジョニングプロファイルは無効（Invalid）になります。
+> - Xcode の「Automatically manage signing」を使っている場合: Xcode が自動で再生成するため追加作業は不要（Xcode でプロジェクトを開き直せば OK）
+> - 手動管理の場合: Portal の **Profiles** から該当プロファイルを Edit → Save で再生成し、ダウンロードし直すこと
+> - CI/CD（App Store 配布用プロファイル等）を使っている場合も同様に再生成が必要
+
+### Services ID / Key は不要
+
+本アプリは **ネイティブ方式**（Apple から直接取得した ID トークンを `signInWithIdToken` で Supabase に渡す方式）のため、
+Web 向け OAuth フローで必要になる以下は **作成不要** です:
+
+- Services ID（`com.xxx.signin` のような Web 用識別子）
+- Sign in with Apple 用の Key（Secret Key / .p8 ファイル）
+
+## 2. Supabase Dashboard
+
+1. [Supabase Dashboard](https://supabase.com/dashboard) で FIT-CONNECT プロジェクトを開く
+2. **Authentication → Sign In / Providers → Apple** を開く
+3. **「Enable Sign in with Apple」を ON** にする
+4. **Client IDs**（Authorized Client IDs）欄にバンドル ID を入力:
+   ```
+   com.fitconnect.fitConnectMobile
+   ```
+5. **Secret Key (for OAuth) は空欄のまま** で Save
+   - ネイティブ `signInWithIdToken` 方式のため Services ID / Secret Key は不要（これらは Web OAuth フロー用）
+
+## 3. 動作確認
+
+- **Simulator の場合**: Settings アプリで Apple ID にサインイン済みであること（未サインインだとネイティブダイアログが進まない）
+- **実機の場合**: iCloud にサインイン済みの iPhone で確認するのが確実
+- 確認手順:
+  1. アプリのログイン画面で「Appleでサインイン」をタップ
+  2. Face ID / パスコードで承認（初回は氏名・メールの共有設定ダイアログが表示される）
+  3. ログイン後、ホーム画面に遷移すればOK
+  4. Supabase Dashboard → Authentication → Users に `apple` プロバイダのユーザーが作成されていることを確認
+
+> **補足（初回のみの氏名取得）:** Apple は**初回サインイン時のみ**氏名を返します。
+> テストでやり直す場合は、iPhone の 設定 → [自分の名前] → サインインとセキュリティ → Appleでサインイン から
+> FIT-CONNECT のApple ID連携を削除すると、再び「初回」として扱われます。
+
+## チェックリスト
+
+- [ ] Apple Developer Portal: App ID に Sign In with Apple capability を有効化
+- [ ] （手動管理の場合）プロビジョニングプロファイルを再生成
+- [ ] Supabase Dashboard: Apple プロバイダを有効化 + Client IDs にバンドル ID を追加
+- [ ] 実機 or Simulator でサインイン動作確認

--- a/fit-connect-mobile/ios/Podfile.lock
+++ b/fit-connect-mobile/ios/Podfile.lock
@@ -120,6 +120,9 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - sign_in_with_apple (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
@@ -143,6 +146,7 @@ DEPENDENCIES:
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -195,6 +199,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sign_in_with_apple:
+    :path: ".symlinks/plugins/sign_in_with_apple/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
@@ -230,6 +236,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sign_in_with_apple: 5e34677a4e74c5f42760f41b3bbe05343e84d171
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b

--- a/fit-connect-mobile/ios/Runner/Runner.entitlements
+++ b/fit-connect-mobile/ios/Runner/Runner.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>

--- a/fit-connect-mobile/lib/features/auth/data/account_deletion_repository.dart
+++ b/fit-connect-mobile/lib/features/auth/data/account_deletion_repository.dart
@@ -1,0 +1,40 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:fit_connect_mobile/services/supabase_service.dart';
+
+part 'account_deletion_repository.g.dart';
+
+/// AccountDeletionRepositoryのProvider
+@riverpod
+AccountDeletionRepository accountDeletionRepository(
+    AccountDeletionRepositoryRef ref) {
+  return AccountDeletionRepository(SupabaseService.client);
+}
+
+/// アカウント削除（delete-account Edge Function 呼び出し）を行うRepository
+class AccountDeletionRepository {
+  final SupabaseClient _supabase;
+
+  AccountDeletionRepository(this._supabase);
+
+  /// delete-account Edge Function を呼び出してアカウントを完全削除する
+  ///
+  /// FunctionsClient は現在のセッションの Authorization ヘッダを自動付与するため、
+  /// 削除対象の指定は不要（Edge Function 側が JWT からユーザーを特定する）。
+  /// 失敗時は例外を投げる（呼び出し元で再試行可能）。
+  Future<void> deleteAccount() async {
+    try {
+      final response = await _supabase.functions.invoke('delete-account');
+      final data = response.data;
+      if (data is! Map || data['success'] != true) {
+        throw Exception('アカウント削除に失敗しました');
+      }
+    } on FunctionException catch (e) {
+      final details = e.details;
+      final message = (details is Map && details['message'] != null)
+          ? details['message']
+          : (e.reasonPhrase ?? 'status ${e.status}');
+      throw Exception('アカウント削除に失敗しました: $message');
+    }
+  }
+}

--- a/fit-connect-mobile/lib/features/auth/data/account_deletion_repository.g.dart
+++ b/fit-connect-mobile/lib/features/auth/data/account_deletion_repository.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_deletion_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$accountDeletionRepositoryHash() =>
+    r'1b5cdaf47e70b564ef29d577f4db09f7ff245ca3';
+
+/// AccountDeletionRepositoryのProvider
+///
+/// Copied from [accountDeletionRepository].
+@ProviderFor(accountDeletionRepository)
+final accountDeletionRepositoryProvider =
+    AutoDisposeProvider<AccountDeletionRepository>.internal(
+  accountDeletionRepository,
+  name: r'accountDeletionRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$accountDeletionRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AccountDeletionRepositoryRef
+    = AutoDisposeProviderRef<AccountDeletionRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/fit-connect-mobile/lib/features/auth/data/auth_repository.dart
+++ b/fit-connect-mobile/lib/features/auth/data/auth_repository.dart
@@ -1,5 +1,10 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:fit_connect_mobile/services/supabase_service.dart';
 
@@ -51,6 +56,84 @@ class AuthRepository {
     );
 
     return response;
+  }
+
+  /// Sign in with Appleでログイン
+  /// sign_in_with_apple パッケージでネイティブダイアログを表示し、
+  /// 取得したIDトークンをSupabase Authに渡す。
+  /// ユーザーがキャンセルした場合はnullを返す。
+  Future<AuthResponse?> signInWithApple() async {
+    // リプレイ攻撃対策のnonce。
+    // Appleにはsha256ハッシュを渡し、Supabaseには生のnonceを渡して検証する。
+    final rawNonce = _generateRandomNonce();
+    final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
+
+    final AuthorizationCredentialAppleID credential;
+    try {
+      credential = await SignInWithApple.getAppleIDCredential(
+        scopes: [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        nonce: hashedNonce,
+      );
+    } on SignInWithAppleAuthorizationException catch (e) {
+      if (e.code == AuthorizationErrorCode.canceled) {
+        // ユーザーがキャンセル
+        return null;
+      }
+      rethrow;
+    }
+
+    final idToken = credential.identityToken;
+    if (idToken == null) {
+      throw Exception('Apple認証でIDトークンを取得できませんでした');
+    }
+
+    final response = await _client.auth.signInWithIdToken(
+      provider: OAuthProvider.apple,
+      idToken: idToken,
+      nonce: rawNonce,
+    );
+
+    // Appleは初回サインイン時のみ氏名を返す。
+    // Google認証で自動設定される user_metadata の full_name と同じキーに保存し、
+    // プロフィール設定画面のプリフィル（profile_setup_screen.dart）に流用する。
+    final fullName = _buildAppleFullName(credential);
+    if (fullName != null) {
+      try {
+        await _client.auth.updateUser(
+          UserAttributes(data: {'full_name': fullName}),
+        );
+      } catch (_) {
+        // 氏名保存はベストエフォート。失敗してもサインイン自体は成功している。
+      }
+    }
+
+    return response;
+  }
+
+  /// Appleから取得した氏名を結合する（日本語アプリのため姓→名の順）。
+  /// 取得できなかった場合はnull。
+  String? _buildAppleFullName(AuthorizationCredentialAppleID credential) {
+    final parts = [credential.familyName, credential.givenName]
+        .whereType<String>()
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
+    if (parts.isEmpty) return null;
+    return parts.join(' ');
+  }
+
+  /// nonce用の暗号学的に安全なランダム文字列を生成する
+  String _generateRandomNonce([int length = 32]) {
+    const charset =
+        '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._';
+    final random = Random.secure();
+    return List.generate(
+      length,
+      (_) => charset[random.nextInt(charset.length)],
+    ).join();
   }
 
   Future<void> signOut() async {

--- a/fit-connect-mobile/lib/features/auth/presentation/screens/login_screen.dart
+++ b/fit-connect-mobile/lib/features/auth/presentation/screens/login_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:fit_connect_mobile/core/theme/app_colors.dart';
 import 'package:fit_connect_mobile/features/auth/data/auth_repository.dart';
@@ -23,6 +24,7 @@ class _LoginScreenState extends State<LoginScreen> {
   final _emailController = TextEditingController();
   bool _isLoading = false;
   bool _isGoogleLoading = false;
+  bool _isAppleLoading = false;
   bool _isEmailSent = false;
   final _authRepository = AuthRepository();
 
@@ -117,6 +119,39 @@ class _LoginScreenState extends State<LoginScreen> {
       }
     }
   }
+
+  Future<void> _handleAppleLogin() async {
+    setState(() {
+      _isAppleLoading = true;
+    });
+
+    try {
+      final response = await _authRepository.signInWithApple();
+      if (response == null) {
+        // ユーザーがキャンセル — 何もしない
+        return;
+      }
+      // 認証成功 → _authSubscription が検知してナビゲーション
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Apple認証エラー: ${e.toString()}'),
+            backgroundColor: AppColors.rose800,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAppleLoading = false;
+        });
+      }
+    }
+  }
+
+  /// いずれかの認証処理が実行中か
+  bool get _isAnyLoading => _isLoading || _isGoogleLoading || _isAppleLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -274,7 +309,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
                           // Login Button
                           ElevatedButton(
-                            onPressed: (_isLoading || _isGoogleLoading) ? null : _handleLogin,
+                            onPressed: _isAnyLoading ? null : _handleLogin,
                             style: ElevatedButton.styleFrom(
                               backgroundColor: AppColors.primary600,
                               foregroundColor: Colors.white,
@@ -329,10 +364,17 @@ class _LoginScreenState extends State<LoginScreen> {
                           ),
                           const SizedBox(height: 24),
 
+                          // Appleでサインインボタン（iOSのみ、App Store Guideline 4.8対応）
+                          // Apple HIG準拠: 他のソーシャルログインボタンより上に配置
+                          if (Platform.isIOS) ...[
+                            _buildAppleSignInButton(context),
+                            const SizedBox(height: 12),
+                          ],
+
                           // Googleでログインボタン
                           OutlinedButton(
                             onPressed:
-                                (_isGoogleLoading || _isLoading) ? null : _handleGoogleLogin,
+                                _isAnyLoading ? null : _handleGoogleLogin,
                             style: OutlinedButton.styleFrom(
                               foregroundColor: colors.textPrimary,
                               side: BorderSide(color: colors.border),
@@ -396,6 +438,56 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  /// Appleデザインガイドライン準拠のサインインボタン。
+  /// 高さ（padding vertical 16）・角丸（12）は既存のGoogleボタンと揃える。
+  /// ライトテーマでは黒ボタン、ダークテーマでは白ボタン（Appleの推奨スタイル）。
+  Widget _buildAppleSignInButton(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backgroundColor = isDark ? Colors.white : Colors.black;
+    final foregroundColor = isDark ? Colors.black : Colors.white;
+
+    return ElevatedButton(
+      onPressed: _isAnyLoading ? null : _handleAppleLogin,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: backgroundColor,
+        foregroundColor: foregroundColor,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        elevation: 0,
+      ),
+      child: _isAppleLoading
+          ? SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                color: foregroundColor,
+                strokeWidth: 2,
+              ),
+            )
+          : Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.apple,
+                  size: 22,
+                  color: foregroundColor,
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  'Appleでサインイン',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    color: foregroundColor,
+                  ),
+                ),
+              ],
+            ),
     );
   }
 }

--- a/fit-connect-mobile/lib/features/auth/providers/auth_provider.dart
+++ b/fit-connect-mobile/lib/features/auth/providers/auth_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' hide User;
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase show User;
+import 'package:fit_connect_mobile/features/auth/data/account_deletion_repository.dart';
 import 'package:fit_connect_mobile/services/supabase_service.dart';
 import 'package:fit_connect_mobile/services/notification_service.dart';
 
@@ -71,6 +72,20 @@ class AuthNotifier extends _$AuthNotifier {
       }
     }
     await SupabaseService.client.auth.signOut();
+  }
+
+  /// アカウント削除（App Store Guideline 5.1.1(v) 対応）
+  ///
+  /// delete-account Edge Function がバックエンドの全データ
+  /// （clients + CASCADE / messages / Storage / auth.users）を削除する。
+  /// 成功後は signOut() でローカルセッションを破棄し、
+  /// app.dart の認証 StreamBuilder がウェルカム画面へ遷移させる。
+  /// 注: FCMトークンは auth.users ごと消えるため掃除は本来不要だが、
+  /// signOut 内の clearTokenFromSupabase は対象行が無くても
+  /// エラーにならない（0行更新 + try-catch 済み）ためそのまま呼んでよい。
+  Future<void> deleteAccount() async {
+    await ref.read(accountDeletionRepositoryProvider).deleteAccount();
+    await signOut();
   }
 }
 

--- a/fit-connect-mobile/lib/features/auth/providers/auth_provider.g.dart
+++ b/fit-connect-mobile/lib/features/auth/providers/auth_provider.g.dart
@@ -44,7 +44,7 @@ final isAuthenticatedProvider = AutoDisposeProvider<bool>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef IsAuthenticatedRef = AutoDisposeProviderRef<bool>;
-String _$authNotifierHash() => r'e7fd4eed0b20e24bf00160fb74f6a95564be7fbe';
+String _$authNotifierHash() => r'afad252e52b58504e8020578f4bb4e0cb6cf7e91';
 
 /// 認証状態を管理するProvider
 /// 注意: プロフィール情報はcurrentClientProvider/trainerProfileProviderを使用

--- a/fit-connect-mobile/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/fit-connect-mobile/lib/features/settings/presentation/screens/settings_screen.dart
@@ -508,6 +508,36 @@ class SettingsScreen extends ConsumerWidget {
             ),
             onTap: () => _showLogoutDialog(context, ref),
           ),
+
+          // アカウント削除ボタン（App Store Guideline 5.1.1(v) 対応）
+          ListTile(
+            leading: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.rose100,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(
+                LucideIcons.userX,
+                size: 20,
+                color: AppColors.rose800,
+              ),
+            ),
+            title: const Text(
+              'アカウントを削除',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: AppColors.rose800,
+              ),
+            ),
+            trailing: Icon(
+              LucideIcons.chevronRight,
+              size: 20,
+              color: colors.textHint,
+            ),
+            onTap: () => _showDeleteAccountDialog(context, ref),
+          ),
         ],
       ),
     );
@@ -704,6 +734,167 @@ class SettingsScreen extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+
+  /// アカウント削除・確認ダイアログ（1段階目: 削除されるデータの説明）
+  void _showDeleteAccountDialog(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('アカウントを削除'),
+        content: const _DeleteAccountWarningContent(),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(
+              'キャンセル',
+              style:
+                  TextStyle(color: AppColors.of(dialogContext).textSecondary),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              _showDeleteAccountConfirmDialog(context, ref);
+            },
+            child: const Text(
+              '続ける',
+              style: TextStyle(
+                color: AppColors.rose800,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// アカウント削除・確認ダイアログ（2段階目: 最終確認 + 実行）
+  void _showDeleteAccountConfirmDialog(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        var isDeleting = false;
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) => AlertDialog(
+            title: const Text('本当に削除しますか？'),
+            content: const Text('この操作は取り消せません。すべてのデータが完全に削除されます。'),
+            actions: [
+              TextButton(
+                onPressed: isDeleting
+                    ? null
+                    : () => Navigator.of(dialogContext).pop(),
+                child: Text(
+                  'キャンセル',
+                  style: TextStyle(
+                      color: AppColors.of(dialogContext).textSecondary),
+                ),
+              ),
+              TextButton(
+                onPressed: isDeleting
+                    ? null
+                    : () async {
+                        setDialogState(() => isDeleting = true);
+                        try {
+                          await ref
+                              .read(authNotifierProvider.notifier)
+                              .deleteAccount();
+                          // 成功: deleteAccount 内で signOut 済み。
+                          // ルーティングはapp.dartのStreamBuilderが自動処理
+                          if (dialogContext.mounted) {
+                            Navigator.of(dialogContext).pop();
+                          }
+                        } catch (e) {
+                          // 失敗: ダイアログを閉じて SnackBar 表示（再試行可能）
+                          if (dialogContext.mounted) {
+                            Navigator.of(dialogContext).pop();
+                          }
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text('アカウントの削除に失敗しました: $e'),
+                                backgroundColor: AppColors.rose800,
+                              ),
+                            );
+                          }
+                        }
+                      },
+                child: isDeleting
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            AppColors.rose800,
+                          ),
+                        ),
+                      )
+                    : const Text(
+                        '削除する',
+                        style: TextStyle(
+                          color: AppColors.rose800,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// アカウント削除ダイアログ（1段階目）の本文
+/// 実装とプレビューで共用するため独立Widgetにしている
+class _DeleteAccountWarningContent extends StatelessWidget {
+  const _DeleteAccountWarningContent();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = AppColors.of(context);
+
+    Widget bullet(String text) => Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('・', style: TextStyle(color: colors.textPrimary)),
+              Expanded(
+                child: Text(
+                  text,
+                  style: TextStyle(color: colors.textPrimary),
+                ),
+              ),
+            ],
+          ),
+        );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'アカウントを削除すると、以下のデータがすべて削除されます。',
+          style: TextStyle(color: colors.textPrimary),
+        ),
+        const SizedBox(height: 12),
+        bullet('体重・食事・運動・睡眠の記録'),
+        bullet('トレーナーとのメッセージと写真'),
+        bullet('セッション・チケット情報'),
+        const SizedBox(height: 12),
+        const Text(
+          'この操作は取り消せません。',
+          style: TextStyle(
+            color: AppColors.rose800,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -989,8 +1180,110 @@ class _PreviewSettingsSection extends StatelessWidget {
               // プレビューでは何もしない
             },
           ),
+
+          // アカウント削除ボタン
+          ListTile(
+            leading: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.rose100,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(
+                LucideIcons.userX,
+                size: 20,
+                color: AppColors.rose800,
+              ),
+            ),
+            title: const Text(
+              'アカウントを削除',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: AppColors.rose800,
+              ),
+            ),
+            trailing: const Icon(
+              LucideIcons.chevronRight,
+              size: 20,
+              color: AppColors.slate400,
+            ),
+            onTap: () {
+              // プレビューでは何もしない
+            },
+          ),
         ],
       ),
     );
   }
+}
+
+@Preview(name: 'DeleteAccountDialog - Step1 削除データ説明')
+Widget previewDeleteAccountDialogStep1() {
+  return MaterialApp(
+    theme: AppTheme.lightTheme,
+    home: Scaffold(
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: AlertDialog(
+          title: const Text('アカウントを削除'),
+          content: const _DeleteAccountWarningContent(),
+          actions: [
+            TextButton(
+              onPressed: () {},
+              child: const Text(
+                'キャンセル',
+                style: TextStyle(color: AppColors.slate600),
+              ),
+            ),
+            TextButton(
+              onPressed: () {},
+              child: const Text(
+                '続ける',
+                style: TextStyle(
+                  color: AppColors.rose800,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+@Preview(name: 'DeleteAccountDialog - Step2 最終確認')
+Widget previewDeleteAccountDialogStep2() {
+  return MaterialApp(
+    theme: AppTheme.lightTheme,
+    home: Scaffold(
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: AlertDialog(
+          title: const Text('本当に削除しますか？'),
+          content: const Text('この操作は取り消せません。すべてのデータが完全に削除されます。'),
+          actions: [
+            TextButton(
+              onPressed: () {},
+              child: const Text(
+                'キャンセル',
+                style: TextStyle(color: AppColors.slate600),
+              ),
+            ),
+            TextButton(
+              onPressed: () {},
+              child: const Text(
+                '削除する',
+                style: TextStyle(
+                  color: AppColors.rose800,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }

--- a/fit-connect-mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/fit-connect-mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -17,6 +17,7 @@ import mobile_scanner
 import path_provider_foundation
 import share_plus
 import shared_preferences_foundation
+import sign_in_with_apple
 import sqflite_darwin
 import url_launcher_macos
 
@@ -33,6 +34,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/fit-connect-mobile/pubspec.lock
+++ b/fit-connect-mobile/pubspec.lock
@@ -266,7 +266,7 @@ packages:
     source: hosted
     version: "0.3.5+1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
@@ -899,10 +899,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1231,6 +1231,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  sign_in_with_apple:
+    dependency: "direct main"
+    description:
+      name: sign_in_with_apple
+      sha256: d284f8e235ab0c5be09a1e9146466912bae8f15f0bd5eb3c4cb999b57cd5c3f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  sign_in_with_apple_platform_interface:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_platform_interface
+      sha256: "981bca52cf3bb9c3ad7ef44aace2d543e5c468bb713fd8dda4275ff76dfa6659"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  sign_in_with_apple_web:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_web
+      sha256: f316400827f52cafcf50d00e1a2e8a0abc534ca1264e856a81c5f06bd5b10fed
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1384,10 +1408,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:
@@ -1605,5 +1629,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"

--- a/fit-connect-mobile/pubspec.yaml
+++ b/fit-connect-mobile/pubspec.yaml
@@ -33,6 +33,10 @@ dependencies:
   # Google認証
   google_sign_in: ^6.2.2
 
+  # Apple認証（App Store Guideline 4.8 対応）
+  sign_in_with_apple: ^8.1.0
+  crypto: ^3.0.7
+
   # QRコード
   mobile_scanner: ^7.1.4
   qr_flutter: ^4.1.0

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -70,13 +70,18 @@ enabled = false
 enabled = false
 
 # Edge Functions の認証設定。
-# どちらも verify_jwt=false（ゲートウェイで JWT 検証しない）。
+# いずれも verify_jwt=false（ゲートウェイで JWT 検証しない）。
 # - parse-message-tags: DB Webhook から呼ばれ user JWT を持たないため必須で false
 # - estimate-meal-nutrition: 関数内で Authorization ヘッダの JWT を自前検証するため false
+# - delete-account: 関数内で Authorization ヘッダの JWT を自前検証するため false
+#   （削除対象は JWT の uid のみ。ボディでの uid 指定は受け付けない）
 # 注: この設定が無いと `supabase functions deploy` が verify_jwt=true をデフォルト適用し、
 #     webhook が 401 で記録停止する事故になる（タスク2.5 デプロイ時の知見）。
 [functions.parse-message-tags]
 verify_jwt = false
 
 [functions.estimate-meal-nutrition]
+verify_jwt = false
+
+[functions.delete-account]
 verify_jwt = false

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,178 @@
+// @ts-nocheck
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const FUNCTION_NAME = 'delete-account'
+
+function errorResponse(code: string, message: string, status: number) {
+  return new Response(JSON.stringify({ error: code, message }), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * 指定フォルダ直下のファイルのフルパス一覧を返す（ベストエフォート）。
+ * Storage の list はフォルダ単位（非再帰）なので、サブフォルダは呼び出し側で列挙する。
+ * エラー時は空配列を返して削除処理を続行させる。
+ */
+async function listFilePaths(
+  supabase: any,
+  bucket: string,
+  folder: string,
+): Promise<string[]> {
+  const { data, error } = await supabase.storage.from(bucket).list(folder, { limit: 1000 })
+  if (error) {
+    console.error(`[${FUNCTION_NAME}] storage list failed (${bucket}/${folder}):`, error)
+    return []
+  }
+  return (data ?? [])
+    // フォルダエントリは id が null（ファイルのみ残す）
+    .filter((item: any) => item.id)
+    .map((item: any) => `${folder}/${item.name}`)
+}
+
+/**
+ * 複数フォルダ配下のファイルをまとめて削除（ベストエフォート）。
+ * Storage の削除失敗でアカウント削除全体を失敗させない（孤児ファイルは残るが実害は小さい）。
+ */
+async function removeFolders(supabase: any, bucket: string, folders: string[]) {
+  try {
+    const paths: string[] = []
+    for (const folder of folders) {
+      paths.push(...(await listFilePaths(supabase, bucket, folder)))
+    }
+    if (paths.length === 0) return
+    const { error } = await supabase.storage.from(bucket).remove(paths)
+    if (error) {
+      console.error(`[${FUNCTION_NAME}] storage remove failed (${bucket}):`, error)
+    }
+  } catch (e) {
+    console.error(`[${FUNCTION_NAME}] storage cleanup error (${bucket}):`, e)
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS })
+  }
+  try {
+    // 1. Auth: 呼び出し元の JWT を自前検証（verify_jwt=false のため必須）
+    //    削除対象は JWT から得た authUid のみ。リクエストボディでの uid 指定は受け付けない
+    //    （他人のアカウントを削除させないため）。
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader?.startsWith('Bearer ')) {
+      return errorResponse('FORBIDDEN', 'No auth token', 403)
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+    const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    })
+    const { data: userData, error: userErr } = await userClient.auth.getUser()
+    if (userErr || !userData.user) {
+      return errorResponse('FORBIDDEN', 'Invalid token', 403)
+    }
+    const authUid = userData.user.id
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // 2. clients 行を取得して trainer_id を控える（Storage の client-notes パス構築に必要）。
+    //    行が無くても後続は続行する: 前回の削除試行が途中で失敗した場合のリトライを
+    //    成功させるため（clients 削除済み・auth 未削除の状態から再開できる）。
+    const { data: client, error: clientErr } = await supabase
+      .from('clients')
+      .select('client_id, trainer_id')
+      .eq('client_id', authUid)
+      .maybeSingle()
+    if (clientErr) {
+      console.error(`[${FUNCTION_NAME}] clients fetch failed:`, clientErr)
+      return errorResponse('DELETE_FAILED', 'Failed to fetch client', 500)
+    }
+    const trainerId: string | null = client?.trainer_id ?? null
+
+    // クライアント専用機能: トレーナーアカウント（clients に行が無く trainers に行がある uid）
+    // からの呼び出しは拒否する。
+    if (!client) {
+      const { data: trainer, error: trainerErr } = await supabase
+        .from('trainers')
+        .select('id')
+        .eq('id', authUid)
+        .maybeSingle()
+      if (trainerErr) {
+        console.error(`[${FUNCTION_NAME}] trainers fetch failed:`, trainerErr)
+        return errorResponse('DELETE_FAILED', 'Failed to verify account type', 500)
+      }
+      if (trainer) {
+        return errorResponse('FORBIDDEN', 'Trainer accounts cannot be deleted here', 403)
+      }
+    }
+
+    // ============================================================
+    // 削除順序は FK 制約上必須（順序を変えると FK 違反で失敗する）:
+    //   (a) clients 行 DELETE
+    //       → weight/meal/exercise/sleep_records・sessions・tickets・
+    //         ticket_subscriptions・workout_assignments(+assignment_exercises)・
+    //         client_notes・ai_estimation_logs が ON DELETE CASCADE で消える
+    //   (b) messages DELETE
+    //       → messages には sender_id/receiver_id の FK が無く CASCADE されないため明示削除。
+    //         かつ *_records.message_id → messages(id) の FK は NO ACTION なので、
+    //         records が残っている間に messages を消すと FK 違反になる。
+    //         したがって (a) clients 削除（= records の CASCADE 削除）より後でなければならない。
+    //   (c) Storage 削除（ベストエフォート）
+    //   (d) auth.users 削除（最後。ここまでのどこかで失敗しても JWT が生きていて再試行できる）
+    // ============================================================
+
+    // 3. (a) clients 行を DELETE（子テーブルは CASCADE で削除される）
+    const { error: deleteClientErr } = await supabase
+      .from('clients')
+      .delete()
+      .eq('client_id', authUid)
+    if (deleteClientErr) {
+      console.error(`[${FUNCTION_NAME}] clients delete failed:`, deleteClientErr)
+      return errorResponse('DELETE_FAILED', 'Failed to delete client data', 500)
+    }
+
+    // 4. (b) messages を DELETE（送信・受信の両方）
+    const { error: deleteMessagesErr } = await supabase
+      .from('messages')
+      .delete()
+      .or(`sender_id.eq.${authUid},receiver_id.eq.${authUid}`)
+    if (deleteMessagesErr) {
+      console.error(`[${FUNCTION_NAME}] messages delete failed:`, deleteMessagesErr)
+      return errorResponse('DELETE_FAILED', 'Failed to delete messages', 500)
+    }
+
+    // 5. (c) Storage をベストエフォート削除（エラーはログのみで続行）
+    // message-photos: {authUid}/ 直下 + AI 推定用サブフォルダ {authUid}/ai/
+    await removeFolders(supabase, 'message-photos', [authUid, `${authUid}/ai`])
+    // client-avatars: {authUid}/ 直下
+    await removeFolders(supabase, 'client-avatars', [authUid])
+    // client-notes: パスが {trainer_id}/{client_id}/ 構造のため trainer_id が取れた場合のみ
+    if (trainerId) {
+      await removeFolders(supabase, 'client-notes', [`${trainerId}/${authUid}`])
+    }
+
+    // 6. (d) auth.users から削除（最後に実行。これが成功した時点で再ログイン不可になる）
+    const { error: deleteAuthErr } = await supabase.auth.admin.deleteUser(authUid)
+    if (deleteAuthErr) {
+      console.error(`[${FUNCTION_NAME}] auth user delete failed:`, deleteAuthErr)
+      return errorResponse('DELETE_FAILED', 'Failed to delete auth user', 500)
+    }
+
+    // 7. 完了
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    })
+  } catch (e) {
+    console.error(`[${FUNCTION_NAME}] error:`, e)
+    return errorResponse('DELETE_FAILED', 'Internal error', 500)
+  }
+})


### PR DESCRIPTION
## 概要

**フェーズ6.2（収益化・リリース準備）**: App Store 審査を止める2つのブロッカーへの対応。

| ブロッカー | 対応 |
| --- | --- |
| Guideline 5.1.1(v): アカウント作成できるアプリはアプリ内削除が必須 | クライアントアカウント削除機能を新設 |
| Guideline 4.8: Google ログインを載せるなら Apple も必須 | Sign in with Apple を追加 |

## アカウント削除の設計

- **Edge Function `delete-account`**: 既存の JWT 自前検証 + service_role パターン。**削除対象は JWT 本人の uid のみ**（ボディでの uid 指定不可 = 任意ユーザー削除を構造的に防止）。トレーナーからの呼び出しは 403
- **削除順序**（FK制約上この順が必須。コードにコメント化済み）:
  1. `clients` 行 DELETE → 記録系11テーブルが CASCADE
  2. `messages` 明示 DELETE（FKなし + `records.message_id` が NO ACTION のため clients より後）
  3. Storage ベストエフォート掃除（`message-photos/{uid}/`+`ai/`、`client-avatars/{uid}/`、`client-notes/{trainerId}/{uid}/`）
  4. `auth.users` 削除（最後 = 途中失敗ならJWT有効のまま再試行可能）
- **Mobile**: 設定画面に削除導線（削除されるデータを箇条書きで明示 → 2段階確認 → ローディング → 失敗時再試行）。成功時は既存 signOut 経由で遷移

## Sign in with Apple の設計

- 既存 Google と同型のネイティブ `signInWithIdToken(OAuthProvider.apple)` 方式（SHA-256 nonce 検証付き、`sign_in_with_apple` 8.1.0）
- ログイン画面の Google ボタン直上に HIG 準拠ボタン（**iOS のみ表示**）。初回取得の氏名は `user_metadata.full_name` へ保存（プロフィール設定のプリフィルと整合）
- `Runner.entitlements` に capability 追加済み

## 検証（実施済み）

| 項目 | 結果 |
| --- | --- |
| **E2E削除テスト（ローカル実DB）** | ✅ seed顧客で実行 → `{"success":true}`、**全11テーブル + auth.users が0件**（削除前: clients 1 / meal 10 / weight 4 / messages 6） |
| セキュリティ | ✅ トレーナーJWT → 403（データ無傷）/ 認証なし → 403 |
| `fvm flutter analyze` | ✅ ベースライン同数（新規指摘ゼロ） |
| `fvm flutter test` | ✅ 59件全パス |
| iOS Simulator | ✅ 統合ビルド・起動・描画確認 |
| `deno check` | ✅ Edge Function 型チェックパス |

## ⚠️ マージ後に必要な作業

1. **Edge Function デプロイ**（私が実行します）: `supabase functions deploy delete-account`
2. **ユーザー作業（Apple まわり・手順書: `fit-connect-mobile/docs/tasks/2026-07-11-apple-signin-setup.md`）**:
   - Apple Developer Portal: App ID に Sign In with Apple capability を有効化
   - Supabase Dashboard: Apple provider 有効化 + Client IDs にバンドルID追加（ネイティブ方式のため Secret 不要）
3. 手動確認: 設定画面の「アカウントを削除」フロー（テストアカウント推奨）と Apple サインイン（外部設定完了後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)