### PR TITLE
feat: Stripe課金コア（Checkout/Portal/webhook + プラン管理画面 + 14日トライアル）フェーズ6.3 PR1

### DIFF
--- a/docs/tasks/2026-07-12-stripe-setup-guide.md
+++ b/docs/tasks/2026-07-12-stripe-setup-guide.md
@@ -1,0 +1,200 @@
+# Stripe 課金 初回セットアップ手順（オーナー作業）
+
+**作成日**: 2026-07-12
+**対象**: プロジェクトオーナー（個人事業主・Stripe アカウント未開設）
+**関連実装**: `feature/stripe-billing-core`（フェーズ6.3 PR1: Checkout / Customer Portal / webhook）
+**関連ドキュメント**: `docs/tasks/2026-07-11-pro-pricing-proposal.md` §6（導入ロードマップ）・§8（確定価格）
+
+コード側（API Routes・DB・課金画面）は実装済みです。動かすためには、以下の Stripe 側セットアップが
+オーナー作業として必要です。**手順1〜6 はすべてテストモードで完結**し、本番アカウント申請（本人確認）
+とは独立して進められます。決定事項（§8 判断10）の通り、本番申請は手順1で並行して開始してください。
+
+確定価格（§8。手順2で使用）:
+
+| プラン | 月額（税込） | 顧客数上限 | Stripe Price |
+| --- | --- | --- | --- |
+| Free | ¥0 | 3人 | 作成不要（DB管理のみ） |
+| Pro | ¥2,980 | 10人 | 要作成 → `STRIPE_PRICE_PRO` |
+| Business | ¥6,980 | 30人 | 要作成 → `STRIPE_PRICE_BUSINESS` |
+
+> 14日 Pro トライアルは **DB 管理（`trial_ends_at`）で Stripe 非関与**のため、
+> Stripe 側にトライアル設定を入れる必要はありません（入れないこと）。
+
+---
+
+## 1. Stripe アカウント作成
+
+- [ ] https://dashboard.stripe.com/register からメールアドレスでアカウント登録する
+- [ ] ダッシュボードに入れることを確認する（右上に「テストモード」トグルがある）
+- [ ] 本番利用の申請（アカウント有効化）を**並行で開始**する: ダッシュボードの「本番環境利用の申請」から
+  事業情報・本人確認書類・銀行口座を提出する
+
+ポイント:
+
+- **テストモードは登録直後から全機能が使える**。本番申請（本人確認・審査）の完了を待つ必要はなく、
+  手順2以降はすぐ進められる
+- 本番申請はオンライン提出後、通常数日で有効化される。準備物（本人確認書類・事業用銀行口座・
+  事業内容の説明・審査対象サイトの要件）は価格提案書 **§6 Phase 1** を参照
+- 審査対象サイトには特商法表記（/tokushoho）等が必要。ページ自体は実装済みだが価格が【要記入】のため、
+  本番公開前に手順7で記入する
+
+---
+
+## 2. テストモードで Product / Price を作成（Pro / Business の2件）
+
+ダッシュボード右上の**「テストモード」トグルが ON** であることを確認してから作業します。
+
+### 2-1. Pro プラン
+
+1. ダッシュボード → **商品カタログ**（Product catalog）→ **商品を追加**
+2. 商品名: `FIT-CONNECT Pro`（説明は任意。例:「顧客10人まで・AI食事解析込み」）
+3. 料金（Price）の設定:
+   - 金額: **2,980**、通貨: **JPY**
+   - 課金体系: **継続（recurring）・月次（Monthly）**
+4. **税の設定（重要）**: 料金設定内の「税の処理（Tax behavior）」を **「内税（税込価格 / inclusive）」** に設定する
+   - 項目が見当たらない場合は料金欄の「詳細オプション」（その他のオプション）を展開すると表示される
+   - ここを既定のままにすると外税扱いになり、表示価格と請求額がずれるため必ず確認すること
+5. 保存後、商品詳細画面の料金欄に表示される **API ID（`price_` で始まる文字列）を控える**
+   → 手順4の `STRIPE_PRICE_PRO` に使用
+
+### 2-2. Business プラン
+
+1. 同様に **商品を追加** → 商品名: `FIT-CONNECT Business`
+2. 金額: **6,980**、通貨: **JPY**、**月次 recurring**、税の処理: **内税（inclusive）**
+3. **API ID（`price_...`）を控える** → 手順4の `STRIPE_PRICE_BUSINESS` に使用
+
+- [ ] Pro（¥2,980・JPY・月次・内税）を作成し `price_...` を控えた
+- [ ] Business（¥6,980・JPY・月次・内税）を作成し `price_...` を控えた
+
+> Free プランは Stripe に作成しない（¥0 プランは DB の `subscription_plan` のみで管理）。
+
+---
+
+## 3. Customer Portal の有効化
+
+解約・カード変更はアプリ内に画面を持たず、Stripe の Customer Portal に任せる構成です
+（`POST /api/billing/portal` がポータルへのリンクを発行する）。有効化しないとポータル遷移が失敗します。
+
+1. ダッシュボード → **設定**（歯車アイコン）→ **Billing** → **Customer Portal**（カスタマーポータル）
+2. 以下を許可する:
+   - **サブスクリプションのキャンセル**（解約）を有効化
+   - **支払い方法の更新**（カード変更）を有効化
+3. **保存**（テストモードでは「テスト環境に保存」）
+
+- [ ] Customer Portal で解約・カード変更を許可し保存した
+
+---
+
+## 4. 環境変数の設定（.env.local と Vercel の両方）
+
+必要な環境変数は次の4つです。**ローカル（`fit-connect/.env.local`）と Vercel の両方**に設定します。
+
+### 4-1. `.env.local` への追記（雛形）
+
+`fit-connect/.env.local` に以下を追記します（値は自分の環境のものに置き換え）:
+
+```bash
+# Stripe（テストモード）
+STRIPE_SECRET_KEY=sk_test_xxxxxxxxxxxx      # ダッシュボード → 開発者 → APIキー → シークレットキー
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx    # 手順5-1（stripe listen）で取得した値
+STRIPE_PRICE_PRO=price_xxxxxxxxxxxx         # 手順2-1で控えた Pro の Price ID
+STRIPE_PRICE_BUSINESS=price_xxxxxxxxxxxx    # 手順2-2で控えた Business の Price ID
+```
+
+> ⚠️ **キーの値は絶対にこのリポジトリにコミットしないこと。**
+> - `.env*` は `.gitignore` 済みだが、別ファイル・ドキュメント・チャットへの貼り付けも禁止
+> - `sk_test_` はテスト用だが、本番切替後の `sk_live_` は決済を実行できる最高権限キーになる。
+>   取り扱いは Vault の service_role キー（`2026-07-10-cron-vault-setup.md`）と同等の警戒で行うこと
+
+### 4-2. Vercel への設定
+
+1. Vercel ダッシュボード → プロジェクト **fit-connect** → **Settings** → **Environment Variables**
+2. 上記4変数を1件ずつ登録する（対象環境は Production。Preview でもテスト決済を試すなら Preview にも）
+   - `STRIPE_WEBHOOK_SECRET` には手順5-2（本番用エンドポイント）で取得する `whsec_` を入れる。
+     手順5-2 完了後に設定でよい
+3. 環境変数はビルド時に読み込まれるため、**設定後に再デプロイ**して反映する
+
+- [ ] `.env.local` に4変数を追記した
+- [ ] Vercel に4変数を登録し、再デプロイした
+
+---
+
+## 5. Webhook の設定
+
+webhook（`POST /api/stripe/webhook`）が `trainers.subscription_plan` と `trainer_billing` を
+自動更新する要のため、ローカル・本番の両方で必ず設定します。署名検証があるので
+`STRIPE_WEBHOOK_SECRET` が実際のエンドポイントと一致していないと全イベントが拒否されます。
+
+### 5-1. ローカル検証用（stripe CLI）
+
+1. stripe CLI をインストールしてログインする:
+
+```bash
+brew install stripe/stripe-cli/stripe
+stripe login   # ブラウザが開くので許可する
+```
+
+2. 開発サーバー（`localhost:3000`）と別のターミナルで転送を起動する:
+
+```bash
+stripe listen --forward-to localhost:3000/api/stripe/webhook
+```
+
+3. 起動時に表示される **`whsec_...` を `.env.local` の `STRIPE_WEBHOOK_SECRET`** に設定し、
+   開発サーバーを再起動する
+
+- [ ] `stripe listen` で取得した `whsec_` を `.env.local` に設定した
+
+> `stripe listen` はローカル検証のたびに起動が必要（起動していない間はローカルに webhook が届かない）。
+
+### 5-2. 本番用（ダッシュボード）
+
+1. ダッシュボード → **開発者** → **Webhook** → **エンドポイントを追加**
+2. エンドポイント URL: `https://<本番ドメイン>/api/stripe/webhook`
+3. 購読イベントとして以下の**4種**を選択する:
+   - `checkout.session.completed`
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+4. 作成後に表示される**署名シークレット（`whsec_...`）を Vercel の `STRIPE_WEBHOOK_SECRET`** に設定し、
+   再デプロイする
+
+- [ ] 本番エンドポイントを4イベントで登録し、`whsec_` を Vercel に設定した
+
+> ⚠️ エンドポイントの `whsec_` は登録先ごとに異なる。ローカル（stripe listen）と本番（ダッシュボード）で
+> 別々の値になるため、`.env.local` と Vercel に同じ値を使い回さないこと。
+
+---
+
+## 6. 動作確認チェックリスト（テストモード）
+
+開発サーバー + `stripe listen` を起動した状態で、以下を順に確認します。
+テストカードは **`4242 4242 4242 4242`**（有効期限: 未来の任意の年月、CVC: 任意の3桁、名前・住所: 任意）。
+
+- [ ] **アップグレード**: `/settings/billing` から Pro を選択 → Stripe Checkout に遷移し、
+  テストカードで決済が完了する
+- [ ] **表示変化**: 決済完了後、`/settings/billing` の表示が Free → **Pro に変わる**
+  （webhook 経由で `trainers.subscription_plan` / `trainer_billing` が自動更新される。
+  数秒待って変わらない場合は `stripe listen` のターミナルでイベント転送と HTTP 200 を確認）
+- [ ] **Portal で解約**: `/settings/billing` から Customer Portal を開き、サブスクリプションをキャンセル
+  → `/settings/billing` の表示が **Free に降格**する
+- [ ] **プロモーションコード**: ダッシュボード → 商品カタログ → **クーポン**でクーポンを作成し
+  プロモーションコードを発行 → Checkout 画面に**コード入力欄が表示され、適用で割引される**
+  （`allow_promotion_codes` は Checkout 実装側で有効化済み）
+- [ ] （任意）Business へのアップグレード / Pro⇄Business の切替も同様に確認する
+
+---
+
+## 7. 本番切替時の TODO
+
+本番アカウント有効化（手順1の申請完了）後、公開前に以下を行います。
+詳細チェックリストは価格提案書 **§6 Phase 2** を参照（本手順書では要点のみ）。
+
+- [ ] **本番モードで Product/Price を再作成**する（手順2と同内容。テストモードの設定は本番にコピーされない）
+- [ ] `STRIPE_SECRET_KEY` を `sk_live_...` に、`STRIPE_PRICE_PRO` / `STRIPE_PRICE_BUSINESS` を
+  本番の Price ID に差し替える（Vercel）
+- [ ] **本番モードで webhook エンドポイントを再設定**し（手順5-2と同内容）、新しい `whsec_` に差し替える
+- [ ] **特商法ページ（/tokushoho）に確定価格・支払時期/方法・解約条件を記入**する（公開の前提条件）
+- [ ] Customer Portal を本番モードでも有効化する（手順3と同内容。設定はモードごとに独立）
+- [ ] そのほか §6 Phase 2 の残項目（規約への課金条項反映、領収書メール設定、webhook 失敗監視、
+  Mobile 側で価格・購入導線に言及しない建付けの維持）を確認する

--- a/docs/tasks/IMPLEMENTATION_TASKS.md
+++ b/docs/tasks/IMPLEMENTATION_TASKS.md
@@ -34,7 +34,7 @@
 | 3 | オンボーディングフロー | Mobile | 0% | 🔴 未着手（実装時はカタログ cat2 3-A の設計を使用） |
 | 4 | ランディングページ | Web | 0% | 🔴 未着手（フェーズ6と連動） |
 | 5 | セキュリティ・基盤修復【緊急】 | Supabase + Web | 60% | 🟡 5.1・5.2 完了 / 5.3 cron migration 化済み・Vault 登録はユーザー作業待ち（手順書: `2026-07-10-cron-vault-setup.md`）/ 5.4 未着手 |
-| 6 | 収益化・リリース準備（Stripe/法務/アカウント削除/Apple Sign-In） | Web + Mobile + Supabase | 35% | 🟡 6.2 完了（アカウント削除 + Sign in with Apple）/ 6.1 ほぼ完了（法務3ページ + user_consents + signup同意。Mobile側の顧客同意UIのみ残）/ 6.3 価格・プラン体系決定済み（実装未着手）/ 6.4〜6.5 未着手 |
+| 6 | 収益化・リリース準備（Stripe/法務/アカウント削除/Apple Sign-In） | Web + Mobile + Supabase | 50% | 🟡 6.2 完了（アカウント削除 + Sign in with Apple）/ 6.1 ほぼ完了（法務3ページ + user_consents + signup同意。Mobile側の顧客同意UIのみ残）/ 6.3 Stripe課金コア実装済み（テスト・本番切替はオーナーのStripeセットアップ待ち。手順書: 2026-07-12-stripe-setup-guide.md）/ 6.4〜6.5 未着手 |
 | 7 | 通知基盤統一（device_tokens + 共通ディスパッチャ） | Supabase + Web + Mobile | 0% | 🔴 未着手 |
 | 8 | 不具合修正・顧客体験の底上げ | Mobile + Web + Supabase | 30% | 🟡 8.1 ワークアウト繰越バグ修正 完了（2026/07/10。拡張の警告通知はフェーズ7待ち）/ 8.2・8.3 未着手 |
 | 9 | トレーナー介入機能（異常検知・トリアージ） | Web + Supabase | 0% | 🔴 未着手 |
@@ -271,10 +271,15 @@
   - [ ] （関連）データエクスポート（個情法の開示請求対応）の方針決定
 - [ ] **6.3 Stripe SaaS 課金**（cat3 1-A、トレーナーサブスク）
   - 価格確定（2026-07-12）: Free ¥0（顧客3人・AI月30回プール）/ Pro ¥2,980税込（〜10人）/ Business ¥6,980税込（〜30人）。14日Proトライアル（クレカ無し）・月額のみ・税込表示。レートリミット 10回/顧客/日 + 100回/顧客/月（超過時テキストのみ）。詳細: docs/tasks/2026-07-11-pro-pricing-proposal.md §8
-  - [ ] Stripe Checkout + Customer Portal + webhook（`subscription_plan` 自動更新）
+  - [x] Stripe Checkout + Customer Portal + webhook（`subscription_plan` 自動更新）
+    - PR: `feature/stripe-billing-core`（API Routes: checkout / portal / status / webhook 署名検証）。14日トライアルは DB 管理（`trial_ends_at`、Stripe 非関与）、`trainer_billing` テーブル新設、`subscription_plan` のクライアント改ざん穴もカラム権限で封鎖（2026/07/12）。テスト・本番切替はオーナーの Stripe セットアップ待ち（手順書: docs/tasks/2026-07-12-stripe-setup-guide.md）
   - [ ] Pro 降格時のモバイル側挙動の設計（AI機能・Pro データの扱い。横断レビュー1-8節）
-  - [ ] Mobile 内では Pro 購入導線に言及しない（IAP 規約対応。表示は機能ゲートのみ）
-  - [ ] `allow_promotion_codes` 有効化（将来の紹介コード cat3 5-A の受け皿）
+  - [ ] Mobile 内では Pro 購入導線に言及しない（IAP 規約対応。表示は機能ゲートのみ。現状違反なしを確認済みだが継続ルールとして残す）
+  - [x] `allow_promotion_codes` 有効化（将来の紹介コード cat3 5-A の受け皿）
+    - Checkout Session 作成時に有効化済み（`feature/stripe-billing-core`、2026/07/12）
+  - [ ] 顧客数上限の enforcement（Free 3 / Pro 10 / Business 30。DB側ゲート + 超過時アップグレード誘導UI）【PR2スコープ】
+  - [ ] AIクォータ新値への書き換え（10回/顧客/日 + 100回/顧客/月 + Free 月30回プール、超過時テキストのみ）【PR2スコープ】
+  - [ ] 特商法ページの価格記入（提供開始時）【PR2スコープ】
 - [ ] **6.4 LP + 料金ページ**（cat3 3-A = 既存フェーズ4 を包含。フェーズ4のタスクリストで管理）
 - [ ] **6.5 支払記録・未払い管理**（cat3 2-A、チケット/月契約と金銭の接続。Stripe Connect 決済代行 cat3 2-B はバックログ）
 

--- a/fit-connect-mobile/lib/features/auth/models/trainer_model.dart
+++ b/fit-connect-mobile/lib/features/auth/models/trainer_model.dart
@@ -17,6 +17,10 @@ class Trainer {
   final bool isOnline;
   @JsonKey(name: 'last_seen_at')
   final DateTime? lastSeenAt;
+  @JsonKey(name: 'subscription_plan')
+  final String? subscriptionPlan;
+  @JsonKey(name: 'trial_ends_at')
+  final DateTime? trialEndsAt;
 
   const Trainer({
     required this.id,
@@ -27,6 +31,8 @@ class Trainer {
     this.updatedAt,
     this.isOnline = false,
     this.lastSeenAt,
+    this.subscriptionPlan,
+    this.trialEndsAt,
   });
 
   factory Trainer.fromJson(Map<String, dynamic> json) =>

--- a/fit-connect-mobile/lib/features/auth/models/trainer_model.g.dart
+++ b/fit-connect-mobile/lib/features/auth/models/trainer_model.g.dart
@@ -21,6 +21,10 @@ Trainer _$TrainerFromJson(Map<String, dynamic> json) => Trainer(
       lastSeenAt: json['last_seen_at'] == null
           ? null
           : DateTime.parse(json['last_seen_at'] as String),
+      subscriptionPlan: json['subscription_plan'] as String?,
+      trialEndsAt: json['trial_ends_at'] == null
+          ? null
+          : DateTime.parse(json['trial_ends_at'] as String),
     );
 
 Map<String, dynamic> _$TrainerToJson(Trainer instance) => <String, dynamic>{
@@ -32,4 +36,6 @@ Map<String, dynamic> _$TrainerToJson(Trainer instance) => <String, dynamic>{
       'updated_at': instance.updatedAt?.toIso8601String(),
       'is_online': instance.isOnline,
       'last_seen_at': instance.lastSeenAt?.toIso8601String(),
+      'subscription_plan': instance.subscriptionPlan,
+      'trial_ends_at': instance.trialEndsAt?.toIso8601String(),
     };

--- a/fit-connect-mobile/lib/features/health/providers/health_sync_provider.g.dart
+++ b/fit-connect-mobile/lib/features/health/providers/health_sync_provider.g.dart
@@ -6,7 +6,7 @@ part of 'health_sync_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$healthSyncHash() => r'38f0a8ab3d19374fdf6f28eb92bc5466fe25af0c';
+String _$healthSyncHash() => r'd0c09157f2a25e6471d95cef99661ab741b22573';
 
 /// See also [HealthSync].
 @ProviderFor(HealthSync)

--- a/fit-connect-mobile/lib/features/records_overview/providers/nutrition_trend_provider.g.dart
+++ b/fit-connect-mobile/lib/features/records_overview/providers/nutrition_trend_provider.g.dart
@@ -6,7 +6,7 @@ part of 'nutrition_trend_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$nutritionTrendHash() => r'0000000000000000000000000000000000000000';
+String _$nutritionTrendHash() => r'e5859fcf87e770ad45ddec2a2b297bb732fa685d';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -41,14 +41,27 @@ const nutritionTrendProvider = NutritionTrendFamily();
 
 /// 体重 + 食事の日次集計（栄養トレンド）を返す Provider。
 ///
+/// 既存の [weightRecordsProvider] / [mealRecordsProvider] を watch し、
+/// `period` の範囲 (startDate 〜 today) の連続した日付配列に対して
+/// 日単位の体重 / カロリー / PFC を集計する。
+///
 /// Copied from [nutritionTrend].
-class NutritionTrendFamily extends Family<AsyncValue<List<DailyNutritionStat>>> {
+class NutritionTrendFamily
+    extends Family<AsyncValue<List<DailyNutritionStat>>> {
   /// 体重 + 食事の日次集計（栄養トレンド）を返す Provider。
+  ///
+  /// 既存の [weightRecordsProvider] / [mealRecordsProvider] を watch し、
+  /// `period` の範囲 (startDate 〜 today) の連続した日付配列に対して
+  /// 日単位の体重 / カロリー / PFC を集計する。
   ///
   /// Copied from [nutritionTrend].
   const NutritionTrendFamily();
 
   /// 体重 + 食事の日次集計（栄養トレンド）を返す Provider。
+  ///
+  /// 既存の [weightRecordsProvider] / [mealRecordsProvider] を watch し、
+  /// `period` の範囲 (startDate 〜 today) の連続した日付配列に対して
+  /// 日単位の体重 / カロリー / PFC を集計する。
   ///
   /// Copied from [nutritionTrend].
   NutritionTrendProvider call({
@@ -85,10 +98,18 @@ class NutritionTrendFamily extends Family<AsyncValue<List<DailyNutritionStat>>> 
 
 /// 体重 + 食事の日次集計（栄養トレンド）を返す Provider。
 ///
+/// 既存の [weightRecordsProvider] / [mealRecordsProvider] を watch し、
+/// `period` の範囲 (startDate 〜 today) の連続した日付配列に対して
+/// 日単位の体重 / カロリー / PFC を集計する。
+///
 /// Copied from [nutritionTrend].
 class NutritionTrendProvider
     extends AutoDisposeFutureProvider<List<DailyNutritionStat>> {
   /// 体重 + 食事の日次集計（栄養トレンド）を返す Provider。
+  ///
+  /// 既存の [weightRecordsProvider] / [mealRecordsProvider] を watch し、
+  /// `period` の範囲 (startDate 〜 today) の連続した日付配列に対して
+  /// 日単位の体重 / カロリー / PFC を集計する。
   ///
   /// Copied from [nutritionTrend].
   NutritionTrendProvider({

--- a/fit-connect-mobile/lib/features/sleep_records/providers/morning_dialog_provider.g.dart
+++ b/fit-connect-mobile/lib/features/sleep_records/providers/morning_dialog_provider.g.dart
@@ -6,7 +6,7 @@ part of 'morning_dialog_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$morningDialogHash() => r'a78261591be8f7eaca56cef2ce7fa9d914700aa3';
+String _$morningDialogHash() => r'c50d5305c7d37ff98029e7a0db4e7298013c70de';
 
 /// 朝ダイアログ表示制御 Provider
 ///

--- a/fit-connect-mobile/lib/features/subscription/providers/ai_features_enabled_provider.dart
+++ b/fit-connect-mobile/lib/features/subscription/providers/ai_features_enabled_provider.dart
@@ -4,10 +4,13 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ai_features_enabled_provider.g.dart';
 
-/// 自身の担当トレーナーの subscription_plan が 'pro' かどうか。
-/// 取得失敗・未認証・未紐付けの場合は false を返す（保守的にAI非表示）。
+/// 自身の担当トレーナーがAI機能を利用可能かどうか（実効プラン判定）。
+/// - subscription_plan が 'pro' または 'business' → 利用可
+/// - 'free' でも trial_ends_at が現在より未来（トライアル中・Pro相当） → 利用可
+/// - それ以外・取得失敗・未認証・未紐付け → false（保守的にAI非表示）
 ///
-/// 参照経路: auth.uid() → clients.client_id → clients.trainer_id → trainers.subscription_plan
+/// 参照経路: auth.uid() → clients.client_id → clients.trainer_id
+///           → trainers.subscription_plan / trainers.trial_ends_at
 // TODO(stage 2): subscribe to auth.onAuthStateChange to invalidate on sign-in/out, and
 //                handle subscription_plan changes (Stripe webhook) to flip the gate live.
 @Riverpod(keepAlive: true)
@@ -33,12 +36,23 @@ Future<bool> aiFeaturesEnabled(AiFeaturesEnabledRef ref) async {
 
     final trainerRow = await supabase
         .from('trainers')
-        .select('subscription_plan')
+        .select('subscription_plan, trial_ends_at')
         .eq('id', trainerId)
         .maybeSingle();
     final plan = trainerRow?['subscription_plan'] as String?;
-    final enabled = plan == 'pro';
-    if (kDebugMode) debugPrint('[aiFeaturesEnabled] trainer=$trainerId plan=$plan → $enabled');
+    final trialEndsAtRaw = trainerRow?['trial_ends_at'] as String?;
+    final trialEndsAt =
+        trialEndsAtRaw != null ? DateTime.tryParse(trialEndsAtRaw) : null;
+    final isPaidPlan = plan == 'pro' || plan == 'business';
+    final isTrialActive =
+        trialEndsAt != null && trialEndsAt.isAfter(DateTime.now());
+    final enabled = isPaidPlan || isTrialActive;
+    if (kDebugMode) {
+      debugPrint(
+        '[aiFeaturesEnabled] trainer=$trainerId plan=$plan '
+        'trialEndsAt=$trialEndsAtRaw → $enabled',
+      );
+    }
     return enabled;
   } catch (e, st) {
     if (kDebugMode) debugPrint('[aiFeaturesEnabled] error: $e\n$st');

--- a/fit-connect-mobile/lib/features/subscription/providers/ai_features_enabled_provider.g.dart
+++ b/fit-connect-mobile/lib/features/subscription/providers/ai_features_enabled_provider.g.dart
@@ -6,12 +6,15 @@ part of 'ai_features_enabled_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$aiFeaturesEnabledHash() => r'0b94306966f993e7868cff9bd8b85de60ede9a46';
+String _$aiFeaturesEnabledHash() => r'42108248a53aa87cb864f5a4ce2070690dda2fc8';
 
-/// 自身の担当トレーナーの subscription_plan が 'pro' かどうか。
-/// 取得失敗・未認証・未紐付けの場合は false を返す（保守的にAI非表示）。
+/// 自身の担当トレーナーがAI機能を利用可能かどうか（実効プラン判定）。
+/// - subscription_plan が 'pro' または 'business' → 利用可
+/// - 'free' でも trial_ends_at が現在より未来（トライアル中・Pro相当） → 利用可
+/// - それ以外・取得失敗・未認証・未紐付け → false（保守的にAI非表示）
 ///
-/// 参照経路: auth.uid() → clients.client_id → clients.trainer_id → trainers.subscription_plan
+/// 参照経路: auth.uid() → clients.client_id → clients.trainer_id
+///           → trainers.subscription_plan / trainers.trial_ends_at
 ///
 /// Copied from [aiFeaturesEnabled].
 @ProviderFor(aiFeaturesEnabled)

--- a/fit-connect/package.json
+++ b/fit-connect/package.json
@@ -37,6 +37,7 @@
     "react-hook-form": "^7.56.4",
     "recharts": "^3.7.0",
     "sonner": "^2.0.7",
+    "stripe": "^22.3.1",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
     "web-push": "^3.6.7",

--- a/fit-connect/pnpm-lock.yaml
+++ b/fit-connect/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      stripe:
+        specifier: ^22.3.1
+        version: 22.3.1(@types/node@20.17.57)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2908,6 +2911,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@22.3.1:
+    resolution: {integrity: sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -6137,6 +6149,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.3.1(@types/node@20.17.57):
+    optionalDependencies:
+      '@types/node': 20.17.57
 
   styled-jsx@5.1.6(react@19.1.0):
     dependencies:

--- a/fit-connect/src/app/(user_console)/settings/billing/page.tsx
+++ b/fit-connect/src/app/(user_console)/settings/billing/page.tsx
@@ -1,0 +1,374 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { Check, ChevronLeft, Loader2 } from 'lucide-react'
+import { supabase } from '@/lib/supabase'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { PLANS, type PlanId } from '@/lib/billing/plans'
+
+interface BillingStatus {
+  billingConfigured: boolean
+  plan: PlanId
+  effectivePlan: PlanId
+  isTrial: boolean
+  trialDaysLeft: number | null
+  trialEndsAt: string | null
+  subscriptionStatus: string | null
+  currentPeriodEnd: string | null
+  cancelAtPeriodEnd: boolean
+  hasStripeCustomer: boolean
+}
+
+const PLAN_ORDER: PlanId[] = ['free', 'pro', 'business']
+
+const AI_FEATURE_NOTES: Record<PlanId, string> = {
+  free: 'AI食事解析 お試し 月30回',
+  pro: 'AI食事解析 利用可（1顧客あたり 日10回・月100回）',
+  business: 'AI食事解析 利用可（1顧客あたり 日10回・月100回）',
+}
+
+const COMMON_FEATURES = [
+  '顧客管理',
+  'ワークアウト計画',
+  'メッセージ',
+  '食事/体重記録',
+  'チケット管理',
+]
+
+function BillingPageContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const checkoutResult = searchParams.get('checkout')
+
+  const [status, setStatus] = useState<BillingStatus | null>(null)
+  const [statusError, setStatusError] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [checkoutPlan, setCheckoutPlan] = useState<PlanId | null>(null)
+  const [portalLoading, setPortalLoading] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const init = async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+
+        if (!user) {
+          router.push('/login')
+          return
+        }
+
+        const res = await fetch('/api/billing/status')
+        if (res.status === 401) {
+          router.push('/login')
+          return
+        }
+        if (!res.ok) {
+          throw new Error(`契約状況の取得に失敗しました (${res.status})`)
+        }
+
+        const data: BillingStatus = await res.json()
+        if (!cancelled) {
+          setStatus(data)
+        }
+      } catch (error) {
+        console.error('契約状況取得エラー:', error)
+        if (!cancelled) {
+          setStatusError(true)
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    init()
+
+    return () => {
+      cancelled = true
+    }
+  }, [router])
+
+  const handleCheckout = async (planId: 'pro' | 'business') => {
+    setActionError(null)
+    setCheckoutPlan(planId)
+
+    try {
+      const res = await fetch('/api/billing/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plan: planId }),
+      })
+
+      if (res.status === 503) {
+        setActionError('決済機能は現在準備中です')
+        setCheckoutPlan(null)
+        return
+      }
+      if (res.status === 401) {
+        router.push('/login')
+        return
+      }
+      if (!res.ok) {
+        throw new Error(`チェックアウトの開始に失敗しました (${res.status})`)
+      }
+
+      const { url } = await res.json()
+      if (!url) {
+        throw new Error('チェックアウトURLが取得できませんでした')
+      }
+
+      // 遷移完了までボタンは無効のままにする（多重送信防止）
+      window.location.href = url
+    } catch (error) {
+      console.error('チェックアウトエラー:', error)
+      setActionError('決済ページへの遷移に失敗しました。時間をおいて再度お試しください。')
+      setCheckoutPlan(null)
+    }
+  }
+
+  const handlePortal = async () => {
+    setActionError(null)
+    setPortalLoading(true)
+
+    try {
+      const res = await fetch('/api/billing/portal', { method: 'POST' })
+
+      if (res.status === 503) {
+        setActionError('決済機能は現在準備中です')
+        setPortalLoading(false)
+        return
+      }
+      if (res.status === 400) {
+        setActionError('お支払い情報が見つかりませんでした')
+        setPortalLoading(false)
+        return
+      }
+      if (!res.ok) {
+        throw new Error(`ポータルの取得に失敗しました (${res.status})`)
+      }
+
+      const { url } = await res.json()
+      if (!url) {
+        throw new Error('ポータルURLが取得できませんでした')
+      }
+
+      // 遷移完了までボタンは無効のままにする
+      window.location.href = url
+    } catch (error) {
+      console.error('ポータル遷移エラー:', error)
+      setActionError('お支払い管理ページへの遷移に失敗しました。時間をおいて再度お試しください。')
+      setPortalLoading(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-48px)]">
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-600 border-t-transparent"></div>
+      </div>
+    )
+  }
+
+  const currentPlan: PlanId | null = status?.effectivePlan ?? null
+  const currentRank = currentPlan ? PLAN_ORDER.indexOf(currentPlan) : null
+  const billingUnavailable = status !== null && !status.billingConfigured
+
+  return (
+    <main className="h-[calc(100vh-48px)] overflow-y-auto bg-gray-50">
+      <div className="max-w-4xl mx-auto p-6 space-y-6">
+        {/* 戻るリンク */}
+        <Link
+          href="/settings"
+          className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 mb-6 cursor-pointer"
+        >
+          <ChevronLeft className="w-4 h-4 mr-1" />
+          設定に戻る
+        </Link>
+
+        {/* ページタイトル */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">プラン・お支払い</h1>
+        </div>
+
+        {/* チェックアウト結果メッセージ */}
+        {checkoutResult === 'success' && (
+          <div className="p-3 rounded-md text-sm bg-emerald-50 text-emerald-700">
+            プランを変更しました。反映まで数秒かかる場合があります
+          </div>
+        )}
+        {checkoutResult === 'cancel' && (
+          <div className="p-3 rounded-md text-sm bg-gray-100 text-gray-600">
+            プランの変更は完了していません。いつでも再度お手続きいただけます。
+          </div>
+        )}
+
+        {/* トライアルバナー */}
+        {status?.isTrial && (
+          <div className="p-4 rounded-md text-sm bg-blue-50 text-blue-800 border border-blue-100">
+            Proプランを無料トライアル中です
+            {status.trialDaysLeft != null && `（残り${status.trialDaysLeft}日）`}
+            。終了後は自動的にFreeプランになります。
+          </div>
+        )}
+
+        {/* 契約状況の取得エラー */}
+        {statusError && (
+          <div className="p-3 rounded-md text-sm bg-gray-100 text-gray-600">
+            現在の契約状況を取得できませんでした。時間をおいてページを再読み込みしてください。
+          </div>
+        )}
+
+        {/* 決済未設定の注記 */}
+        {billingUnavailable && (
+          <div className="p-3 rounded-md text-sm bg-gray-100 text-gray-600">
+            決済機能は現在準備中です
+          </div>
+        )}
+
+        {/* 操作エラー */}
+        {actionError && (
+          <div role="alert" className="p-3 rounded-md text-sm bg-rose-50 text-rose-700">
+            {actionError}
+          </div>
+        )}
+
+        {/* プラン比較カード */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {PLAN_ORDER.map((planId) => {
+            const plan = PLANS[planId]
+            const isCurrent = currentPlan === planId
+            const rank = PLAN_ORDER.indexOf(planId)
+            const isUpgrade =
+              !isCurrent && (currentRank === null ? planId !== 'free' : rank > currentRank)
+            const isCheckingOut = checkoutPlan === planId
+
+            return (
+              <Card
+                key={planId}
+                className={cn('flex flex-col', isCurrent && 'border-primary')}
+              >
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-2">
+                    <CardTitle className="text-lg">{plan.label}</CardTitle>
+                    {isCurrent ? (
+                      <span className="inline-flex items-center rounded-md bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground whitespace-nowrap">
+                        現在のプラン
+                      </span>
+                    ) : plan.recommended ? (
+                      <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary whitespace-nowrap">
+                        おすすめ
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="pt-2">
+                    <span className="text-3xl font-bold text-gray-900">
+                      ¥{plan.priceJpy.toLocaleString('ja-JP')}
+                    </span>
+                    <span className="ml-1 text-sm text-gray-500">/月（税込）</span>
+                  </div>
+                  <CardDescription>顧客{plan.maxClients}人まで</CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-1 flex-col">
+                  <ul className="space-y-2 text-sm text-gray-700">
+                    <li className="flex items-start gap-2">
+                      <Check className="w-4 h-4 mt-0.5 shrink-0 text-teal-600" />
+                      <span>{AI_FEATURE_NOTES[planId]}</span>
+                    </li>
+                    {COMMON_FEATURES.map((feature) => (
+                      <li key={feature} className="flex items-start gap-2">
+                        <Check className="w-4 h-4 mt-0.5 shrink-0 text-teal-600" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-auto pt-6">
+                    {isCurrent ? (
+                      <Button variant="outline" className="w-full" disabled>
+                        利用中
+                      </Button>
+                    ) : isUpgrade ? (
+                      <Button
+                        className="w-full cursor-pointer"
+                        disabled={checkoutPlan !== null || billingUnavailable}
+                        onClick={() => handleCheckout(planId as 'pro' | 'business')}
+                      >
+                        {isCheckingOut ? (
+                          <>
+                            <Loader2 className="animate-spin" />
+                            処理中...
+                          </>
+                        ) : (
+                          'このプランにする'
+                        )}
+                      </Button>
+                    ) : (
+                      <p className="text-xs text-gray-500 text-center py-2">
+                        お支払い管理から変更できます
+                      </p>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+
+        {/* お支払い管理 */}
+        {status?.hasStripeCustomer && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">お支払い管理</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {status.cancelAtPeriodEnd && (
+                <div className="p-3 rounded-md text-sm bg-amber-50 text-amber-800">
+                  現在の期間終了時に解約予定です
+                </div>
+              )}
+              <p className="text-sm text-gray-600">
+                お支払い方法の変更・解約のお手続きは、Stripeのお客様ポータルから行えます。
+              </p>
+              <Button
+                variant="outline"
+                className="cursor-pointer"
+                disabled={portalLoading}
+                onClick={handlePortal}
+              >
+                {portalLoading && <Loader2 className="animate-spin" />}
+                お支払い方法・解約の管理
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* フッタ注記 */}
+        <p className="text-xs text-gray-500 text-center pb-6">
+          価格はすべて税込です。決済は Stripe により安全に処理されます。
+        </p>
+      </div>
+    </main>
+  )
+}
+
+export default function BillingPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center h-[calc(100vh-48px)]">
+          <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-600 border-t-transparent"></div>
+        </div>
+      }
+    >
+      <BillingPageContent />
+    </Suspense>
+  )
+}

--- a/fit-connect/src/app/(user_console)/settings/page.tsx
+++ b/fit-connect/src/app/(user_console)/settings/page.tsx
@@ -8,6 +8,7 @@ import { useUserStore } from '@/store/userStore'
 import { ProfileSection } from '@/components/settings/ProfileSection'
 import { ScheduleSection } from '@/components/settings/ScheduleSection'
 import { NotificationSection } from '@/components/settings/NotificationSection'
+import { BillingSection } from '@/components/settings/BillingSection'
 import { AccountSection } from '@/components/settings/AccountSection'
 import type { Trainer } from '@/types/trainer'
 
@@ -91,6 +92,9 @@ export default function SettingsPage() {
 
         {/* 通知設定 */}
         <NotificationSection trainerId={trainer.id} />
+
+        {/* プラン・お支払い */}
+        <BillingSection />
 
         {/* アカウント管理 */}
         <AccountSection onLogout={handleLogout} />

--- a/fit-connect/src/app/api/billing/checkout/route.ts
+++ b/fit-connect/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthenticatedUser } from '@/lib/supabase/server'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+import { getStripe, isBillingConfigured } from '@/lib/billing/stripe'
+
+/**
+ * リダイレクト先のベース URL を解決する。
+ * 優先順: リクエストヘッダーの origin → NEXT_PUBLIC_APP_URL → req.nextUrl.origin
+ */
+function resolveOrigin(req: NextRequest): string {
+  const originHeader = req.headers.get('origin')
+  if (originHeader) return originHeader
+  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
+  return req.nextUrl.origin
+}
+
+/**
+ * POST /api/billing/checkout
+ * Body: { plan: 'pro' | 'business' }
+ * Stripe Checkout セッションを作成し、リダイレクト先 URL を返す。
+ */
+export async function POST(req: NextRequest) {
+  try {
+    // 認証必須
+    const user = await getAuthenticatedUser()
+    if (!user) {
+      return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+    }
+
+    // リクエストボディ検証
+    let plan: unknown
+    try {
+      const body = await req.json()
+      plan = body?.plan
+    } catch {
+      return NextResponse.json({ error: 'INVALID_BODY' }, { status: 400 })
+    }
+    if (plan !== 'pro' && plan !== 'business') {
+      return NextResponse.json({ error: 'INVALID_PLAN' }, { status: 400 })
+    }
+
+    // Stripe 未設定（キー申請中）の場合は 503
+    if (!isBillingConfigured()) {
+      return NextResponse.json(
+        { error: 'BILLING_NOT_CONFIGURED' },
+        { status: 503 }
+      )
+    }
+    const priceId =
+      plan === 'pro'
+        ? process.env.STRIPE_PRICE_PRO
+        : process.env.STRIPE_PRICE_BUSINESS
+    if (!priceId) {
+      return NextResponse.json(
+        { error: 'BILLING_NOT_CONFIGURED' },
+        { status: 503 }
+      )
+    }
+
+    // trainers 行の取得
+    const { data: trainer, error: trainerError } = await supabaseAdmin
+      .from('trainers')
+      .select('id, email')
+      .eq('id', user.id)
+      .maybeSingle()
+    if (trainerError) {
+      console.error('checkout: trainers 取得エラー:', trainerError)
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+    }
+    if (!trainer) {
+      return NextResponse.json({ error: 'TRAINER_NOT_FOUND' }, { status: 404 })
+    }
+
+    // trainer_billing の取得
+    const { data: billing, error: billingError } = await supabaseAdmin
+      .from('trainer_billing')
+      .select('stripe_customer_id')
+      .eq('trainer_id', user.id)
+      .maybeSingle()
+    if (billingError) {
+      console.error('checkout: trainer_billing 取得エラー:', billingError)
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+    }
+
+    const stripe = getStripe()
+
+    // Stripe Customer が未作成なら作成して保存
+    let customerId: string | null = billing?.stripe_customer_id ?? null
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: trainer.email || user.email || undefined,
+        metadata: { trainer_id: user.id },
+      })
+      customerId = customer.id
+
+      const { error: upsertError } = await supabaseAdmin
+        .from('trainer_billing')
+        .upsert(
+          {
+            trainer_id: user.id,
+            stripe_customer_id: customerId,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: 'trainer_id' }
+        )
+      if (upsertError) {
+        console.error('checkout: trainer_billing upsert エラー:', upsertError)
+        return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+      }
+    }
+
+    const origin = resolveOrigin(req)
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      allow_promotion_codes: true,
+      client_reference_id: user.id,
+      subscription_data: { metadata: { trainer_id: user.id } },
+      success_url: `${origin}/settings/billing?checkout=success`,
+      cancel_url: `${origin}/settings/billing?checkout=cancel`,
+    })
+
+    if (!session.url) {
+      console.error('checkout: セッション URL が空です:', session.id)
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+    }
+
+    return NextResponse.json({ url: session.url })
+  } catch (error) {
+    console.error('checkout: 予期しないエラー:', error)
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+  }
+}

--- a/fit-connect/src/app/api/billing/portal/route.ts
+++ b/fit-connect/src/app/api/billing/portal/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthenticatedUser } from '@/lib/supabase/server'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+import { getStripe, isBillingConfigured } from '@/lib/billing/stripe'
+
+/**
+ * リダイレクト先のベース URL を解決する。
+ * 優先順: リクエストヘッダーの origin → NEXT_PUBLIC_APP_URL → req.nextUrl.origin
+ */
+function resolveOrigin(req: NextRequest): string {
+  const originHeader = req.headers.get('origin')
+  if (originHeader) return originHeader
+  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL
+  return req.nextUrl.origin
+}
+
+/**
+ * POST /api/billing/portal
+ * Stripe Billing Portal セッションを作成し、リダイレクト先 URL を返す。
+ * 支払い方法の変更・プラン変更・解約はポータル側で行う。
+ */
+export async function POST(req: NextRequest) {
+  try {
+    // 認証必須
+    const user = await getAuthenticatedUser()
+    if (!user) {
+      return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+    }
+
+    // Stripe 未設定（キー申請中）の場合は 503
+    if (!isBillingConfigured()) {
+      return NextResponse.json(
+        { error: 'BILLING_NOT_CONFIGURED' },
+        { status: 503 }
+      )
+    }
+
+    const { data: billing, error: billingError } = await supabaseAdmin
+      .from('trainer_billing')
+      .select('stripe_customer_id')
+      .eq('trainer_id', user.id)
+      .maybeSingle()
+    if (billingError) {
+      console.error('portal: trainer_billing 取得エラー:', billingError)
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+    }
+
+    const customerId = billing?.stripe_customer_id
+    if (!customerId) {
+      return NextResponse.json({ error: 'NO_CUSTOMER' }, { status: 400 })
+    }
+
+    const origin = resolveOrigin(req)
+    const session = await getStripe().billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${origin}/settings/billing`,
+    })
+
+    return NextResponse.json({ url: session.url })
+  } catch (error) {
+    console.error('portal: 予期しないエラー:', error)
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+  }
+}

--- a/fit-connect/src/app/api/billing/status/route.ts
+++ b/fit-connect/src/app/api/billing/status/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import { getAuthenticatedUser } from '@/lib/supabase/server'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+import { isBillingConfigured } from '@/lib/billing/stripe'
+import { getEffectivePlan, type PlanId } from '@/lib/billing/plans'
+
+/** DB の text 値を PlanId に安全に変換する（不正値は 'free' 扱い） */
+function toPlanId(value: string | null | undefined): PlanId {
+  return value === 'pro' || value === 'business' ? value : 'free'
+}
+
+/**
+ * GET /api/billing/status
+ * 現在のトレーナーの課金状態を返す（設定画面 UI との契約）。
+ *
+ * Response:
+ * {
+ *   billingConfigured, plan, effectivePlan, isTrial, trialDaysLeft,
+ *   trialEndsAt, subscriptionStatus, currentPeriodEnd, cancelAtPeriodEnd,
+ *   hasStripeCustomer
+ * }
+ */
+export async function GET() {
+  try {
+    // 認証必須
+    const user = await getAuthenticatedUser()
+    if (!user) {
+      return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+    }
+
+    const { data: trainer, error: trainerError } = await supabaseAdmin
+      .from('trainers')
+      .select('id, subscription_plan, trial_ends_at')
+      .eq('id', user.id)
+      .maybeSingle()
+    if (trainerError) {
+      console.error('billing/status: trainers 取得エラー:', trainerError)
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+    }
+    if (!trainer) {
+      return NextResponse.json({ error: 'TRAINER_NOT_FOUND' }, { status: 404 })
+    }
+
+    const { data: billing, error: billingError } = await supabaseAdmin
+      .from('trainer_billing')
+      .select(
+        'stripe_customer_id, subscription_status, current_period_end, cancel_at_period_end'
+      )
+      .eq('trainer_id', user.id)
+      .maybeSingle()
+    if (billingError) {
+      console.error('billing/status: trainer_billing 取得エラー:', billingError)
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+    }
+
+    const plan = toPlanId(trainer.subscription_plan)
+    const trialEndsAt: string | null = trainer.trial_ends_at ?? null
+    const effective = getEffectivePlan(plan, trialEndsAt)
+
+    return NextResponse.json({
+      billingConfigured: isBillingConfigured(),
+      plan,
+      effectivePlan: effective.plan,
+      isTrial: effective.isTrial,
+      trialDaysLeft: effective.trialDaysLeft,
+      trialEndsAt,
+      subscriptionStatus: billing?.subscription_status ?? null,
+      currentPeriodEnd: billing?.current_period_end ?? null,
+      cancelAtPeriodEnd: Boolean(billing?.cancel_at_period_end),
+      hasStripeCustomer: Boolean(billing?.stripe_customer_id),
+    })
+  } catch (error) {
+    console.error('billing/status: 予期しないエラー:', error)
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+  }
+}

--- a/fit-connect/src/app/api/stripe/webhook/route.ts
+++ b/fit-connect/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from 'next/server'
+import type Stripe from 'stripe'
+import { getStripe, isBillingConfigured } from '@/lib/billing/stripe'
+import { supabaseAdmin } from '@/lib/supabaseAdmin'
+import {
+  resolvePlanFromSubscription,
+  type SubscriptionSnapshot,
+} from '@/lib/billing/webhook'
+
+// Node.js runtime（デフォルト）を維持すること。
+// 生ボディの署名検証と Stripe SDK 利用のため Edge runtime は使用不可。
+
+/**
+ * サブスクリプションの状態を trainers / trainer_billing に同期する。
+ *
+ * trainer_id の解決: subscription.metadata.trainer_id を優先し、
+ * 無ければ trainer_billing を stripe_customer_id で逆引きする。
+ * 解決できない場合はエラーログのみ（Stripe に再送させないため throw しない）。
+ */
+async function syncSubscription(sub: Stripe.Subscription): Promise<void> {
+  const customerId =
+    typeof sub.customer === 'string' ? sub.customer : sub.customer?.id ?? null
+
+  // trainer_id の解決
+  let trainerId: string | null = sub.metadata?.trainer_id || null
+  if (!trainerId && customerId) {
+    const { data, error } = await supabaseAdmin
+      .from('trainer_billing')
+      .select('trainer_id')
+      .eq('stripe_customer_id', customerId)
+      .maybeSingle()
+    if (error) {
+      throw new Error(`trainer_billing 逆引きエラー: ${error.message}`)
+    }
+    trainerId = data?.trainer_id ?? null
+  }
+  if (!trainerId) {
+    // 解決不能: 再送しても解決しないため、エラーログのみで正常終了扱い
+    console.error(
+      `stripe/webhook: trainer_id を解決できません (subscription=${sub.id}, customer=${customerId})`
+    )
+    return
+  }
+
+  const { plan, billingPatch } = resolvePlanFromSubscription(
+    sub as SubscriptionSnapshot
+  )
+
+  // trainer_billing の更新（書き込みは service_role のみ）
+  const { error: billingError } = await supabaseAdmin
+    .from('trainer_billing')
+    .upsert(
+      {
+        trainer_id: trainerId,
+        ...(customerId ? { stripe_customer_id: customerId } : {}),
+        stripe_subscription_id: billingPatch.stripe_subscription_id,
+        subscription_status: billingPatch.subscription_status,
+        price_id: billingPatch.price_id,
+        current_period_end: billingPatch.current_period_end,
+        cancel_at_period_end: billingPatch.cancel_at_period_end,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'trainer_id' }
+    )
+  if (billingError) {
+    throw new Error(`trainer_billing 更新エラー: ${billingError.message}`)
+  }
+
+  // trainers.subscription_plan の更新（plan が null の場合は現状維持）
+  if (plan) {
+    const { error: trainerError } = await supabaseAdmin
+      .from('trainers')
+      .update({
+        subscription_plan: plan,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', trainerId)
+    if (trainerError) {
+      throw new Error(`trainers 更新エラー: ${trainerError.message}`)
+    }
+  }
+}
+
+/**
+ * POST /api/stripe/webhook
+ * Stripe からの webhook を受信し、署名検証のうえサブスクリプション状態を同期する。
+ */
+export async function POST(req: Request) {
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+  if (!webhookSecret || !isBillingConfigured()) {
+    return NextResponse.json(
+      { error: 'BILLING_NOT_CONFIGURED' },
+      { status: 503 }
+    )
+  }
+
+  const signature = req.headers.get('stripe-signature')
+  if (!signature) {
+    return NextResponse.json({ error: 'MISSING_SIGNATURE' }, { status: 400 })
+  }
+
+  // 署名検証は必ず生ボディに対して行う（先に JSON パースしないこと）
+  const rawBody = await req.text()
+
+  let event: Stripe.Event
+  try {
+    event = getStripe().webhooks.constructEvent(
+      rawBody,
+      signature,
+      webhookSecret
+    )
+  } catch (error) {
+    console.error('stripe/webhook: 署名検証エラー:', error)
+    return NextResponse.json({ error: 'INVALID_SIGNATURE' }, { status: 400 })
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session
+        const subscriptionId =
+          typeof session.subscription === 'string'
+            ? session.subscription
+            : session.subscription?.id ?? null
+        if (subscriptionId) {
+          const subscription =
+            await getStripe().subscriptions.retrieve(subscriptionId)
+          await syncSubscription(subscription)
+        }
+        break
+      }
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted': {
+        await syncSubscription(event.data.object as Stripe.Subscription)
+        break
+      }
+      default:
+        // その他のイベントは何もせず 200 を返す
+        break
+    }
+  } catch (error) {
+    // DB 更新失敗など一時的なエラーは 500 を返して Stripe に再送させる
+    console.error(`stripe/webhook: イベント処理エラー (${event.type}):`, error)
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/fit-connect/src/components/settings/BillingSection.tsx
+++ b/fit-connect/src/components/settings/BillingSection.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { PLANS, type PlanId } from '@/lib/billing/plans'
+
+interface BillingStatusSummary {
+  effectivePlan: PlanId
+  isTrial: boolean
+  trialDaysLeft: number | null
+}
+
+export function BillingSection() {
+  const [status, setStatus] = useState<BillingStatusSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch('/api/billing/status')
+        if (!res.ok) {
+          throw new Error(`契約状況の取得に失敗しました (${res.status})`)
+        }
+        const data: BillingStatusSummary = await res.json()
+        if (!cancelled) {
+          setStatus(data)
+        }
+      } catch (error) {
+        console.error('契約状況取得エラー:', error)
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchStatus()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>プラン・お支払い</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-600">現在のプラン</p>
+          {loading ? (
+            <div className="h-6 w-20 rounded-md bg-gray-100 animate-pulse" />
+          ) : status ? (
+            <div className="flex items-center gap-2">
+              {status.isTrial && (
+                <span className="text-xs text-blue-700">
+                  Proトライアル中
+                  {status.trialDaysLeft != null && `（残り${status.trialDaysLeft}日）`}
+                </span>
+              )}
+              <span className="inline-flex items-center rounded-md bg-gray-100 px-2.5 py-0.5 text-sm font-medium text-gray-900">
+                {PLANS[status.effectivePlan]?.label ?? status.effectivePlan}
+              </span>
+            </div>
+          ) : (
+            <span className="text-sm text-gray-400">-</span>
+          )}
+        </div>
+        <div className="border-t pt-1">
+          <Link
+            href="/settings/billing"
+            className="flex items-center justify-between p-3 -mx-3 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
+          >
+            <p className="text-sm font-medium text-gray-900">プランを管理</p>
+            <ChevronRight className="w-5 h-5 text-gray-400" />
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/fit-connect/src/lib/billing/plans.test.ts
+++ b/fit-connect/src/lib/billing/plans.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  PLANS,
+  TRIAL_DAYS,
+  getEffectivePlan,
+  planFromPriceId,
+} from '@/lib/billing/plans'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+describe('PLANS / TRIAL_DAYS', () => {
+  it('3プランが定義され、価格と顧客上限が仕様通り', () => {
+    expect(PLANS.free).toMatchObject({ id: 'free', priceJpy: 0, maxClients: 3 })
+    expect(PLANS.pro).toMatchObject({
+      id: 'pro',
+      priceJpy: 2980,
+      maxClients: 10,
+      recommended: true,
+    })
+    expect(PLANS.business).toMatchObject({
+      id: 'business',
+      priceJpy: 6980,
+      maxClients: 30,
+    })
+  })
+
+  it('トライアルは14日', () => {
+    expect(TRIAL_DAYS).toBe(14)
+  })
+})
+
+describe('getEffectivePlan', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-12T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('free + トライアル期限が未来 → Pro トライアル中', () => {
+    const trialEndsAt = new Date(Date.now() + 5 * DAY_MS).toISOString()
+    expect(getEffectivePlan('free', trialEndsAt)).toEqual({
+      plan: 'pro',
+      isTrial: true,
+      trialDaysLeft: 5,
+    })
+  })
+
+  it('残り1時間でも trialDaysLeft は 1（切り上げ）', () => {
+    const trialEndsAt = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    expect(getEffectivePlan('free', trialEndsAt)).toEqual({
+      plan: 'pro',
+      isTrial: true,
+      trialDaysLeft: 1,
+    })
+  })
+
+  it('free + トライアル期限切れ → free', () => {
+    const trialEndsAt = new Date(Date.now() - 1 * DAY_MS).toISOString()
+    expect(getEffectivePlan('free', trialEndsAt)).toEqual({
+      plan: 'free',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+  })
+
+  it('free + 期限がちょうど今 → free（未来のみトライアル扱い）', () => {
+    const trialEndsAt = new Date(Date.now()).toISOString()
+    expect(getEffectivePlan('free', trialEndsAt)).toEqual({
+      plan: 'free',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+  })
+
+  it('free + trial_ends_at が null → free', () => {
+    expect(getEffectivePlan('free', null)).toEqual({
+      plan: 'free',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+  })
+
+  it('free + 不正な日付文字列 → free', () => {
+    expect(getEffectivePlan('free', 'not-a-date')).toEqual({
+      plan: 'free',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+  })
+
+  it('pro 契約中はトライアル期限に関係なく pro', () => {
+    const future = new Date(Date.now() + 5 * DAY_MS).toISOString()
+    expect(getEffectivePlan('pro', future)).toEqual({
+      plan: 'pro',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+    expect(getEffectivePlan('pro', null)).toEqual({
+      plan: 'pro',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+  })
+
+  it('business 契約中は business', () => {
+    expect(getEffectivePlan('business', null)).toEqual({
+      plan: 'business',
+      isTrial: false,
+      trialDaysLeft: null,
+    })
+  })
+})
+
+describe('planFromPriceId', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('STRIPE_PRICE_PRO に一致 → pro', () => {
+    vi.stubEnv('STRIPE_PRICE_PRO', 'price_pro_123')
+    vi.stubEnv('STRIPE_PRICE_BUSINESS', 'price_biz_456')
+    expect(planFromPriceId('price_pro_123')).toBe('pro')
+  })
+
+  it('STRIPE_PRICE_BUSINESS に一致 → business', () => {
+    vi.stubEnv('STRIPE_PRICE_PRO', 'price_pro_123')
+    vi.stubEnv('STRIPE_PRICE_BUSINESS', 'price_biz_456')
+    expect(planFromPriceId('price_biz_456')).toBe('business')
+  })
+
+  it('どちらにも一致しない → null', () => {
+    vi.stubEnv('STRIPE_PRICE_PRO', 'price_pro_123')
+    vi.stubEnv('STRIPE_PRICE_BUSINESS', 'price_biz_456')
+    expect(planFromPriceId('price_unknown')).toBeNull()
+  })
+
+  it('null / undefined / 空文字 → null', () => {
+    vi.stubEnv('STRIPE_PRICE_PRO', 'price_pro_123')
+    expect(planFromPriceId(null)).toBeNull()
+    expect(planFromPriceId(undefined)).toBeNull()
+    expect(planFromPriceId('')).toBeNull()
+  })
+
+  it('env 未設定なら一致判定しない（空 env と空 priceId が誤マッチしない）', () => {
+    vi.stubEnv('STRIPE_PRICE_PRO', '')
+    vi.stubEnv('STRIPE_PRICE_BUSINESS', '')
+    expect(planFromPriceId('price_pro_123')).toBeNull()
+  })
+})

--- a/fit-connect/src/lib/billing/plans.ts
+++ b/fit-connect/src/lib/billing/plans.ts
@@ -1,0 +1,95 @@
+/**
+ * プラン定義の単一情報源（Single Source of Truth）
+ *
+ * - UI（設定画面）とAPI（checkout/status/webhook）の両方から参照される
+ * - 環境変数 STRIPE_PRICE_PRO / STRIPE_PRICE_BUSINESS は呼び出し時に評価する
+ *   （module スコープで参照しない — env 未設定でもビルド・他機能が動くこと）
+ */
+
+export type PlanId = 'free' | 'pro' | 'business'
+
+export interface PlanDef {
+  id: PlanId
+  label: string
+  priceJpy: number
+  maxClients: number
+  recommended?: boolean
+}
+
+export const PLANS: Record<PlanId, PlanDef> = {
+  free: {
+    id: 'free',
+    label: 'Free',
+    priceJpy: 0,
+    maxClients: 3,
+  },
+  pro: {
+    id: 'pro',
+    label: 'Pro',
+    priceJpy: 2980,
+    maxClients: 10,
+    recommended: true,
+  },
+  business: {
+    id: 'business',
+    label: 'Business',
+    priceJpy: 6980,
+    maxClients: 30,
+  },
+}
+
+export const TRIAL_DAYS = 14
+
+export interface EffectivePlan {
+  plan: PlanId
+  isTrial: boolean
+  trialDaysLeft: number | null
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * 実効プランを算出する。
+ *
+ * - subscription_plan が 'free' 以外（有料契約中）→ そのプラン
+ * - 'free' かつ trial_ends_at が未来 → Pro トライアル中
+ * - それ以外 → free
+ */
+export function getEffectivePlan(
+  subscriptionPlan: PlanId,
+  trialEndsAt: string | null
+): EffectivePlan {
+  if (subscriptionPlan !== 'free') {
+    return { plan: subscriptionPlan, isTrial: false, trialDaysLeft: null }
+  }
+
+  if (trialEndsAt) {
+    const endMs = new Date(trialEndsAt).getTime()
+    const nowMs = Date.now()
+    if (Number.isFinite(endMs) && endMs > nowMs) {
+      return {
+        plan: 'pro',
+        isTrial: true,
+        trialDaysLeft: Math.ceil((endMs - nowMs) / MS_PER_DAY),
+      }
+    }
+  }
+
+  return { plan: 'free', isTrial: false, trialDaysLeft: null }
+}
+
+/**
+ * Stripe Price ID からプランを逆引きする。
+ * env（STRIPE_PRICE_PRO / STRIPE_PRICE_BUSINESS）と突合し、
+ * 一致しない・env 未設定の場合は null を返す。
+ */
+export function planFromPriceId(priceId: string | null | undefined): PlanId | null {
+  if (!priceId) return null
+
+  const proPriceId = process.env.STRIPE_PRICE_PRO
+  const businessPriceId = process.env.STRIPE_PRICE_BUSINESS
+
+  if (proPriceId && priceId === proPriceId) return 'pro'
+  if (businessPriceId && priceId === businessPriceId) return 'business'
+  return null
+}

--- a/fit-connect/src/lib/billing/stripe.ts
+++ b/fit-connect/src/lib/billing/stripe.ts
@@ -1,0 +1,35 @@
+import Stripe from 'stripe'
+
+/**
+ * Stripe クライアントの遅延初期化。
+ *
+ * STRIPE_SECRET_KEY はオーナー申請中で未設定の可能性があるため、
+ * module スコープでは絶対に参照しない。env 未設定でも import 自体は安全で、
+ * ビルド・デプロイ・他機能に影響しない。
+ */
+
+let stripeClient: Stripe | null = null
+
+/** STRIPE_SECRET_KEY が設定されているか（課金機能が有効か） */
+export function isBillingConfigured(): boolean {
+  return Boolean(process.env.STRIPE_SECRET_KEY)
+}
+
+/**
+ * Stripe クライアントを返す（初回呼び出し時に生成）。
+ * STRIPE_SECRET_KEY 未設定なら throw する。
+ * 呼び出し側は事前に isBillingConfigured() でガードすること。
+ */
+export function getStripe(): Stripe {
+  const secretKey = process.env.STRIPE_SECRET_KEY
+  if (!secretKey) {
+    throw new Error(
+      'STRIPE_SECRET_KEY is not configured. Billing features are unavailable.'
+    )
+  }
+  if (!stripeClient) {
+    // apiVersion は SDK デフォルト（pinned version）に任せる
+    stripeClient = new Stripe(secretKey)
+  }
+  return stripeClient
+}

--- a/fit-connect/src/lib/billing/webhook.test.ts
+++ b/fit-connect/src/lib/billing/webhook.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  resolvePlanFromSubscription,
+  type SubscriptionSnapshot,
+} from '@/lib/billing/webhook'
+
+const PRO_PRICE = 'price_pro_123'
+const BIZ_PRICE = 'price_biz_456'
+
+// 2026-07-12T00:00:00Z の unix 秒
+const PERIOD_END_UNIX = 1783900800
+const PERIOD_END_ISO = new Date(PERIOD_END_UNIX * 1000).toISOString()
+
+function sub(over: Partial<SubscriptionSnapshot> = {}): SubscriptionSnapshot {
+  return {
+    id: 'sub_test_1',
+    status: 'active',
+    cancel_at_period_end: false,
+    items: {
+      data: [{ price: { id: PRO_PRICE }, current_period_end: PERIOD_END_UNIX }],
+    },
+    ...over,
+  }
+}
+
+describe('resolvePlanFromSubscription', () => {
+  beforeEach(() => {
+    vi.stubEnv('STRIPE_PRICE_PRO', PRO_PRICE)
+    vi.stubEnv('STRIPE_PRICE_BUSINESS', BIZ_PRICE)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('active + pro price → plan=pro、patch に契約情報一式', () => {
+    const result = resolvePlanFromSubscription(sub())
+    expect(result.plan).toBe('pro')
+    expect(result.billingPatch).toEqual({
+      stripe_subscription_id: 'sub_test_1',
+      subscription_status: 'active',
+      price_id: PRO_PRICE,
+      current_period_end: PERIOD_END_ISO,
+      cancel_at_period_end: false,
+    })
+  })
+
+  it('active + business price → plan=business', () => {
+    const result = resolvePlanFromSubscription(
+      sub({
+        items: {
+          data: [
+            { price: { id: BIZ_PRICE }, current_period_end: PERIOD_END_UNIX },
+          ],
+        },
+      })
+    )
+    expect(result.plan).toBe('business')
+    expect(result.billingPatch.price_id).toBe(BIZ_PRICE)
+  })
+
+  it('trialing → active と同様に price からプランを反映', () => {
+    const result = resolvePlanFromSubscription(sub({ status: 'trialing' }))
+    expect(result.plan).toBe('pro')
+    expect(result.billingPatch.subscription_status).toBe('trialing')
+  })
+
+  it('active + 未知の price → plan=null（プラン維持）', () => {
+    const result = resolvePlanFromSubscription(
+      sub({
+        items: { data: [{ price: { id: 'price_unknown' } }] },
+      })
+    )
+    expect(result.plan).toBeNull()
+    expect(result.billingPatch.price_id).toBe('price_unknown')
+  })
+
+  it('past_due → plan=null（プラン維持、status のみ記録）', () => {
+    const result = resolvePlanFromSubscription(sub({ status: 'past_due' }))
+    expect(result.plan).toBeNull()
+    expect(result.billingPatch.subscription_status).toBe('past_due')
+  })
+
+  it('canceled → plan=free', () => {
+    const result = resolvePlanFromSubscription(sub({ status: 'canceled' }))
+    expect(result.plan).toBe('free')
+    expect(result.billingPatch.subscription_status).toBe('canceled')
+  })
+
+  it('unpaid → plan=free', () => {
+    expect(resolvePlanFromSubscription(sub({ status: 'unpaid' })).plan).toBe(
+      'free'
+    )
+  })
+
+  it('incomplete_expired → plan=free', () => {
+    expect(
+      resolvePlanFromSubscription(sub({ status: 'incomplete_expired' })).plan
+    ).toBe('free')
+  })
+
+  it('incomplete / paused など未分類の status → plan=null（維持）', () => {
+    expect(
+      resolvePlanFromSubscription(sub({ status: 'incomplete' })).plan
+    ).toBeNull()
+    expect(
+      resolvePlanFromSubscription(sub({ status: 'paused' })).plan
+    ).toBeNull()
+  })
+
+  it('cancel_at_period_end=true が patch に反映される', () => {
+    const result = resolvePlanFromSubscription(
+      sub({ cancel_at_period_end: true })
+    )
+    expect(result.plan).toBe('pro') // プランは維持（期間末解約予約）
+    expect(result.billingPatch.cancel_at_period_end).toBe(true)
+  })
+
+  it('current_period_end: item に無ければトップレベルから取得（旧API互換）', () => {
+    const result = resolvePlanFromSubscription(
+      sub({
+        current_period_end: PERIOD_END_UNIX,
+        items: { data: [{ price: { id: PRO_PRICE } }] },
+      })
+    )
+    expect(result.billingPatch.current_period_end).toBe(PERIOD_END_ISO)
+  })
+
+  it('current_period_end がどこにも無ければ null', () => {
+    const result = resolvePlanFromSubscription(
+      sub({ items: { data: [{ price: { id: PRO_PRICE } }] } })
+    )
+    expect(result.billingPatch.current_period_end).toBeNull()
+  })
+
+  it('items が空でも落ちない（price_id=null、plan は canceled 系のみ変化）', () => {
+    const active = resolvePlanFromSubscription(sub({ items: { data: [] } }))
+    expect(active.plan).toBeNull()
+    expect(active.billingPatch.price_id).toBeNull()
+
+    const canceled = resolvePlanFromSubscription(
+      sub({ status: 'canceled', items: { data: [] } })
+    )
+    expect(canceled.plan).toBe('free')
+  })
+})

--- a/fit-connect/src/lib/billing/webhook.ts
+++ b/fit-connect/src/lib/billing/webhook.ts
@@ -1,0 +1,98 @@
+import { planFromPriceId, type PlanId } from './plans'
+
+/**
+ * Stripe webhook イベント → DB 更新内容を導出する純関数群。
+ * I/O を持たないためユニットテスト対象（webhook.test.ts）。
+ */
+
+/**
+ * Stripe.Subscription の構造的サブセット。
+ * 純関数をテスト可能に保つため、Stripe SDK の型に依存しない。
+ *
+ * current_period_end は Stripe API バージョンにより
+ * サブスクリプション直下（旧）または items.data[].current_period_end（新, Basil 以降）
+ * に存在するため、両方を許容する。単位は unix 秒。
+ */
+export interface SubscriptionSnapshot {
+  id: string
+  status: string
+  cancel_at_period_end: boolean
+  current_period_end?: number | null
+  items: {
+    data: Array<{
+      price: { id: string }
+      current_period_end?: number | null
+    }>
+  }
+}
+
+/** trainer_billing テーブルへの更新内容 */
+export interface BillingPatch {
+  stripe_subscription_id: string
+  subscription_status: string
+  price_id: string | null
+  current_period_end: string | null
+  cancel_at_period_end: boolean
+}
+
+export interface ResolvedSubscription {
+  /**
+   * trainers.subscription_plan に反映すべきプラン。
+   * null の場合はプラン変更なし（現状維持。status の記録のみ行う）。
+   */
+  plan: PlanId | null
+  billingPatch: BillingPatch
+}
+
+/** subscription_plan を 'free' に落とすステータス */
+const DOWNGRADE_STATUSES = new Set(['canceled', 'unpaid', 'incomplete_expired'])
+
+/** priceId のプランを反映するステータス */
+const ACTIVE_STATUSES = new Set(['active', 'trialing'])
+
+function toIsoOrNull(unixSeconds: number | null | undefined): string | null {
+  if (typeof unixSeconds !== 'number' || !Number.isFinite(unixSeconds)) {
+    return null
+  }
+  return new Date(unixSeconds * 1000).toISOString()
+}
+
+/**
+ * サブスクリプションの状態から、trainers.subscription_plan の更新値と
+ * trainer_billing の更新内容を導出する。
+ *
+ * マッピング:
+ * - active / trialing        → planFromPriceId(price) のプラン（price 不明なら維持）
+ * - past_due                 → プラン維持（status 記録のみ）
+ * - canceled / unpaid /
+ *   incomplete_expired       → 'free'
+ * - その他（incomplete 等）  → プラン維持（status 記録のみ）
+ */
+export function resolvePlanFromSubscription(
+  sub: SubscriptionSnapshot
+): ResolvedSubscription {
+  const firstItem = sub.items?.data?.[0]
+  const priceId = firstItem?.price?.id ?? null
+
+  // current_period_end: item レベル（新API）優先、無ければトップレベル（旧API）
+  const periodEndUnix = firstItem?.current_period_end ?? sub.current_period_end
+
+  const billingPatch: BillingPatch = {
+    stripe_subscription_id: sub.id,
+    subscription_status: sub.status,
+    price_id: priceId,
+    current_period_end: toIsoOrNull(periodEndUnix),
+    cancel_at_period_end: Boolean(sub.cancel_at_period_end),
+  }
+
+  let plan: PlanId | null = null
+  if (DOWNGRADE_STATUSES.has(sub.status)) {
+    plan = 'free'
+  } else if (ACTIVE_STATUSES.has(sub.status)) {
+    // 未知の price（env 未設定・プラン外の price）の場合は null = プラン維持
+    plan = planFromPriceId(priceId)
+  }
+  // past_due やその他のステータスは plan = null（維持）のまま
+
+  return { plan, billingPatch }
+}

--- a/fit-connect/src/lib/supabase/server.ts
+++ b/fit-connect/src/lib/supabase/server.ts
@@ -1,0 +1,47 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import type { User } from '@supabase/supabase-js'
+
+/**
+ * Route Handler / Server Component 用の認証ヘルパー。
+ *
+ * リクエストの Cookie からセッションを復元し、Supabase Auth サーバーで
+ * 検証済みのユーザーを返す（auth.getUser() は JWT をサーバー側で検証する）。
+ * 未認証・検証失敗時は null。
+ *
+ * 課金系 API Route は必ずこのヘルパーで認証チェックを行うこと。
+ */
+export async function getAuthenticatedUser(): Promise<User | null> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // Server Component から呼ばれた場合など、Cookie を書き込めない
+            // コンテキストでは無視する（セッション読み取りには影響しない）
+          }
+        },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error || !user) {
+    return null
+  }
+  return user
+}

--- a/fit-connect/src/types/trainer.ts
+++ b/fit-connect/src/types/trainer.ts
@@ -3,6 +3,8 @@ export type Trainer = {
   name: string
   email: string
   profile_image_url: string | null
+  subscription_plan: 'free' | 'pro' | 'business'
+  trial_ends_at: string | null
   created_at: string
   updated_at: string
 }

--- a/supabase/functions/estimate-meal-nutrition/index.ts
+++ b/supabase/functions/estimate-meal-nutrition/index.ts
@@ -220,12 +220,19 @@ Deno.serve(async (req) => {
     }
 
     // 3. subscription gate
+    // 実効プラン規則: pro / business は利用可。free でも trial_ends_at が未来なら
+    // トライアル中（Pro相当）として利用可。それ以外は不可。
     const { data: trainer, error: trainerErr } = await supabase
       .from('trainers')
-      .select('id, subscription_plan')
+      .select('id, subscription_plan, trial_ends_at')
       .eq('id', client.trainer_id)
       .maybeSingle()
-    if (trainerErr || !trainer || trainer.subscription_plan !== 'pro') {
+    const plan = trainer?.subscription_plan
+    const isPaidPlan = plan === 'pro' || plan === 'business'
+    const isTrialActive =
+      typeof trainer?.trial_ends_at === 'string' &&
+      new Date(trainer.trial_ends_at).getTime() > Date.now()
+    if (trainerErr || !trainer || !(isPaidPlan || isTrialActive)) {
       return errorResponse('FORBIDDEN', 'AI features require pro plan', 403)
     }
 

--- a/supabase/migrations/20260712000000_add_billing_foundation.sql
+++ b/supabase/migrations/20260712000000_add_billing_foundation.sql
@@ -1,0 +1,162 @@
+-- Migration: add_billing_foundation
+-- 目的: Stripe 課金基盤の DB 土台を整備する。
+--   1. trainers.subscription_plan の CHECK 制約を ('free','pro') → ('free','pro','business') に拡張
+--   2. trainers.trial_ends_at を追加（14日 Pro トライアルの期限。cron 不要のDB管理方式）
+--   3. trainer_billing テーブル新設（Stripe 機微情報の分離先。書き込みは service_role のみ）
+--   4. trainers のカラムレベル書き込み保護（トレーナー本人による subscription_plan 改ざん防止）
+--
+-- 背景（セキュリティ）:
+--   - trainers の RLS は trainers_select_all USING(true) / trainers_update_own USING(id=auth.uid()) /
+--     trainers_insert_own WITH CHECK(id=auth.uid()) であり、update_own にカラム制限がない。
+--     さらに 20251230131753_remote_schema.sql の ALTER DEFAULT PRIVILEGES により
+--     anon / authenticated へ GRANT ALL が付与されるため、トレーナー本人が anon key + 自分の JWT で
+--     subscription_plan='pro' に UPDATE できてしまう穴があった → 本 migration の §4 で修正。
+--   - trainers_select_all が USING(true) のため、Stripe 顧客IDを trainers に置くと全公開になる
+--     → trainer_billing テーブルに分離（§3）。
+
+-- ============================================================
+-- 1. subscription_plan CHECK 制約の張り替え
+-- ============================================================
+-- 既存制約は 20260502120100_add_subscription_plan_to_trainers.sql の
+-- インラインカラム CHECK（自動命名: trainers_subscription_plan_check）。
+-- pg_constraint ガード付きで冪等に DROP + ADD する（20260710010000〜010002 のパターン踏襲）。
+
+DO $$
+BEGIN
+  -- 'business' を含まない旧定義のときだけ DROP（再実行時は no-op）
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trainers_subscription_plan_check'
+      AND conrelid = 'public.trainers'::regclass
+      AND pg_get_constraintdef(oid) NOT LIKE '%business%'
+  ) THEN
+    ALTER TABLE public.trainers DROP CONSTRAINT trainers_subscription_plan_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'trainers_subscription_plan_check'
+      AND conrelid = 'public.trainers'::regclass
+  ) THEN
+    ALTER TABLE public.trainers
+      ADD CONSTRAINT trainers_subscription_plan_check
+      CHECK (subscription_plan IN ('free', 'pro', 'business'));
+  END IF;
+END $$;
+
+-- NOT NULL DEFAULT 'free' は 20260502120100 のまま維持（本 migration では触らない）
+
+COMMENT ON COLUMN public.trainers.subscription_plan IS
+  'サブスクリプションプラン（free / pro / business）。Stripe Webhook（service_role）のみが更新する';
+
+-- ============================================================
+-- 2. trainers.trial_ends_at（14日 Pro トライアル期限）
+-- ============================================================
+-- 実効プラン = plan != 'free' ? plan : (trial_ends_at > now() ? 'pro'(トライアル中) : 'free')
+-- をアプリ側で計算する方式（cron 不要）。行作成時点から14日のトライアル。
+--
+-- 注意: DEFAULT 付き ADD COLUMN のため、既存行にも「migration 適用時点 + 14日」で
+-- backfill される。既存行は現状テストユーザーのみであり、この挙動はオーナー決定として許容済み。
+
+ALTER TABLE public.trainers
+  ADD COLUMN IF NOT EXISTS trial_ends_at timestamptz DEFAULT (now() + interval '14 days');
+
+COMMENT ON COLUMN public.trainers.trial_ends_at IS
+  '14日 Pro トライアルの期限。実効プランはアプリ側で plan!=''free'' ? plan : (trial_ends_at > now() ? pro(trial) : free) と計算する。service_role のみが更新可能';
+
+-- ============================================================
+-- 3. trainer_billing テーブル（Stripe 機微情報の分離先）
+-- ============================================================
+-- trainers は trainers_select_all USING(true) で全公開のため、Stripe 顧客ID等は
+-- 本テーブルに分離する。書き込みポリシーは一切作成しない = service_role 専用書き込み。
+
+CREATE TABLE IF NOT EXISTS public.trainer_billing (
+  trainer_id uuid PRIMARY KEY REFERENCES public.trainers(id) ON DELETE CASCADE,
+  stripe_customer_id text UNIQUE,
+  stripe_subscription_id text,
+  subscription_status text,
+  price_id text,
+  current_period_end timestamptz,
+  cancel_at_period_end boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.trainer_billing IS
+  'Stripe 課金情報（トレーナー単位）。書き込みは service_role（Stripe Webhook / API Route）のみ。本人は SELECT のみ可';
+
+ALTER TABLE public.trainer_billing ENABLE ROW LEVEL SECURITY;
+
+-- updated_at 自動更新（既存の public.update_updated_at_column() を再利用。
+-- 20251230131753_remote_schema.sql で定義済み・trainers 等でも使用中）
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_updated_at_trainer_billing') THEN
+    CREATE TRIGGER set_updated_at_trainer_billing
+      BEFORE UPDATE ON public.trainer_billing
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();
+  END IF;
+END $$;
+
+-- RLS ポリシー: 本人 SELECT のみ（INSERT/UPDATE/DELETE ポリシー無し = service_role のみ書き込み可）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'trainer_billing' AND policyname = 'trainer_billing_select_own'
+  ) THEN
+    CREATE POLICY "trainer_billing_select_own"
+      ON public.trainer_billing
+      FOR SELECT
+      TO authenticated
+      USING (trainer_id = auth.uid());
+  END IF;
+END $$;
+
+-- ALTER DEFAULT PRIVILEGES（20251230131753）により anon / authenticated へ GRANT ALL が
+-- 自動付与されるため、明示的に剥がす（多層防御。RLS だけに頼らない）。
+-- authenticated には SELECT のみ残す（行の絞り込みは上記 RLS ポリシーが担う）。
+REVOKE ALL ON public.trainer_billing FROM anon;
+REVOKE ALL ON public.trainer_billing FROM authenticated;
+GRANT SELECT ON public.trainer_billing TO authenticated;
+-- service_role は DEFAULT PRIVILEGES で ALL 付与済み（RLS もバイパスする）
+
+-- ============================================================
+-- 4. trainers のカラムレベル書き込み保護
+-- ============================================================
+-- テーブル全体の INSERT/UPDATE 権限を剥がし、クライアントが実際に書くカラムのみ
+-- カラムレベル GRANT で許可し直す。subscription_plan / trial_ends_at は絶対に含めない。
+--
+-- 非 service_role クライアントからの trainers 書き込み箇所（2026-07-12 grep 全数調査）:
+--   [UPDATE]
+--   - fit-connect-mobile/lib/services/notification_service.dart
+--       L220: .from('trainers').update({'fcm_token': token}).eq('id', userId)     … FCMトークン登録
+--       L244: .from('trainers').update({'fcm_token': null}).eq('id', userId)      … ログアウト時削除
+--       L310: .from('trainers').update({'fcm_token': newToken}).eq('id', ...)     … トークンリフレッシュ
+--     → fcm_token が現行コードで唯一のクライアント UPDATE カラム
+--   - is_online / last_seen_at（20260307122114 のプレゼンスカラム）:
+--     現行コードに PostgREST 経由の書き込みは未検出（mobile は読み取り + Realtime 購読のみ）だが、
+--     トレーナー本人のプレゼンス更新用に設計されたカラムであり機微情報でもないため UPDATE を許可する
+--   - name / email / profile_image_url（本人プロフィール）:
+--     現行のクライアント書き込みは Web updateTrainer.ts（service_role）経由のみだが、
+--     trainers_update_own ポリシー（本人行の更新を想定）との互換維持のため UPDATE を許可する。
+--     いずれも trainers_select_all で全公開済みのカラムであり機微情報ではない
+--   [INSERT]
+--   - fit-connect/src/lib/supabase/createTrainer.ts
+--       L7-8: .from('trainers').insert([{ id, name, email }])  … browser client（ANON_KEY）
+--     → 現在どこからも import されていない死にコードだが、trainers_insert_own ポリシーとの
+--       互換維持のため id / name / email / profile_image_url の INSERT を許可しておく
+--   [対象外（service_role 経由のため本 GRANT の影響を受けない）]
+--   - fit-connect/src/lib/supabase/updateTrainer.ts（supabaseAdmin: name/email/profile_image_url）
+--   - fit-connect/src/app/auth/callback/route.ts（supabaseAdmin: upsert id/name/email/profile_image_url）
+--   - fit-connect/src/app/api/trainers/create/route.ts（supabaseAdmin: insert id/name/email）
+
+REVOKE INSERT, UPDATE ON public.trainers FROM anon, authenticated;
+
+GRANT UPDATE (name, email, profile_image_url, fcm_token, is_online, last_seen_at)
+  ON public.trainers TO authenticated;
+GRANT INSERT (id, name, email, profile_image_url) ON public.trainers TO authenticated;
+
+-- SELECT 権限は既存のまま（trainers_select_all による全件読み取りは QR コード連携フローで必要）。
+-- anon には INSERT/UPDATE を一切戻さない。


### PR DESCRIPTION
## 概要

フェーズ6.3 PR1: **Stripe サブスク課金のコア実装**（テストモード前提・Stripeキー未設定でも安全に稼働）。
2026-07-12 確定の価格体系（提案書 §8）を実装しています。

| プラン | 月額（税込） | 顧客数上限 |
| --- | --- | --- |
| Free | ¥0 | 3人 |
| Pro（おすすめ） | ¥2,980 | 10人 |
| Business | ¥6,980 | 30人 |

+ 14日Proトライアル（クレカ登録なし・DB管理）、月額のみ、`allow_promotion_codes` 有効。

## 変更内容

### DB（migration `20260712000000_add_billing_foundation.sql`）
- `subscription_plan` CHECK に `'business'` を追加（冪等ガード付き）
- `trainers.trial_ends_at` 新設（行作成+14日。実効プラン = 有料プラン or トライアル中はPro相当、をアプリ側で計算 → 失効cron不要）
- `trainer_billing` テーブル新設: Stripe customer/subscription ID等の置き場。`trainers` は全公開SELECTのため機微情報を分離。書き込みは service_role のみ、SELECT は本人のみ
- **🔒 セキュリティ修正**: `trainers` のカラム権限を再構成。従来はトレーナー本人がクライアントSDKで自分の `subscription_plan` を `'pro'` に改ざん可能だった穴を封鎖（UPDATE 許可は name/email/profile_image_url/fcm_token/is_online/last_seen_at のみ。クライアント書き込み実態は grep で全数確認済み）

### Web（fit-connect）
- `src/lib/billing/plans.ts` — プラン定義・実効プラン計算の単一情報源
- API 4本（**全て毎リクエスト認証**。既存の認証なしAPIパターンは踏襲していません）
  - `POST /api/billing/checkout` — Checkout Session（promotion codes 有効）
  - `POST /api/billing/portal` — Customer Portal
  - `GET /api/billing/status` — UI用の契約状況
  - `POST /api/stripe/webhook` — 生ボディ署名検証。checkout.session.completed / customer.subscription.* で `subscription_plan` + `trainer_billing` を自動更新。DB更新失敗時は 500 で Stripe に再送させる
- **キー未設定でも安全**: 遅延初期化 + 503 `BILLING_NOT_CONFIGURED`（UIは「決済機能は現在準備中です」表示）。ビルドも通る
- UI: `/settings/billing`（3カード比較・トライアルバナー・Portal導線・checkout成否メッセージ）+ 設定トップに「プラン・お支払い」セクション

### AIゲート（同一リリース必須の改修）
- `estimate-meal-nutrition` と Mobile `aiFeaturesEnabledProvider` の `== 'pro'` 完全一致判定を「pro / business / トライアル中」に拡張（**拒否レスポンス形式は不変**）
- Web `Trainer` 型 / Mobile `Trainer` モデルに `subscription_plan`・`trial_ends_at` を追加（build_runner 再生成。stale だった無関係の生成ファイル3件も決定的に再同期）

### ドキュメント
- [2026-07-12-stripe-setup-guide.md](docs/tasks/2026-07-12-stripe-setup-guide.md) — **あなた向けのセットアップ手順書**（アカウント作成 → テストモードで Price 作成（内税設定）→ Portal 有効化 → env 設定 → webhook → 動作確認チェックリスト）
- IMPLEMENTATION_TASKS.md 6.3 更新（フェーズ6: 35%→50%）

## 検証

| 項目 | 結果 |
| --- | --- |
| `tsc --noEmit`（統合） | ✅ |
| vitest | ✅ 50件（新規28件: 実効プラン計算・webhookマッピング） |
| `next build` | ✅（Stripeキー未設定のまま成功） |
| ローカル `db reset` 全チェーン + 冪等再実行 | ✅ |
| カラム権限テスト（psql） | ✅ 改ざんUPDATE拒否 / fcm_token更新可 / anon読み取り互換維持 / trainer_billing RLS本人のみ |
| `flutter analyze` / `flutter test` | ✅ 既存比増分ゼロ / 59件全パス |
| ブラウザQA（ログイン済みChrome） | ✅ プラン画面表示・認証ガード・API 401/503・「準備中」フォールバック・設定トップ・ダッシュボード回帰 |

## マージ後の作業（私がやります）

1. `supabase db push`（trial_ends_at 等の適用。**現在リモート未適用のため、本番の /settings/billing は「契約状況を取得できませんでした」表示になりますが、適用で解消**）
2. `supabase functions deploy estimate-meal-nutrition`（migration 適用後に実施）

## あなたにお願いする作業（並行でOK）

- 手順書に沿って Stripe アカウント作成〜テストモードのセットアップ（完了後にE2E課金テストが可能になります）

## PR2 スコープ（このPRに含まない）

- 顧客数上限の enforcement（DB側ゲート + 超過時アップグレード誘導UI）
- AIクォータ新値（10回/顧客/日 + 100回/顧客/月 + Free月30回プール、超過時テキストのみ）
- 特商法ページの価格記入（提供開始時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
