### PR TITLE
feat: プラン上限とAIクォータのenforcement（顧客数DBトリガー + 新レートリミット + Free月30回プール）フェーズ6.3 PR2

### DIFF
--- a/docs/tasks/IMPLEMENTATION_TASKS.md
+++ b/docs/tasks/IMPLEMENTATION_TASKS.md
@@ -277,8 +277,10 @@
   - [ ] Mobile 内では Pro 購入導線に言及しない（IAP 規約対応。表示は機能ゲートのみ。現状違反なしを確認済みだが継続ルールとして残す）
   - [x] `allow_promotion_codes` 有効化（将来の紹介コード cat3 5-A の受け皿）
     - Checkout Session 作成時に有効化済み（`feature/stripe-billing-core`、2026/07/12）
-  - [ ] 顧客数上限の enforcement（Free 3 / Pro 10 / Business 30。DB側ゲート + 超過時アップグレード誘導UI）【PR2スコープ】
-  - [ ] AIクォータ新値への書き換え（10回/顧客/日 + 100回/顧客/月 + Free 月30回プール、超過時テキストのみ）【PR2スコープ】
+  - [x] 顧客数上限の enforcement（Free 3 / Pro 10 / Business 30。DB側ゲート + 超過時アップグレード誘導UI）【PR2スコープ】
+    - DBトリガー enforce_client_limit + Web招待モーダルの誘導UI + Mobile登録エラーハンドリング（2026/07/12、PR: feature/plan-limits-enforcement）
+  - [x] AIクォータ新値への書き換え（10回/顧客/日 + 100回/顧客/月 + Free 月30回プール、超過時テキストのみ）【PR2スコープ】
+    - 10回/顧客/日 + 100回/顧客/月（超過時テキストのみ）+ Free月30回プール。Freeにも AI お試し開放、Mobile の AI ボタンゲートも開放（2026/07/12、同PR）
   - [ ] 特商法ページの価格記入（提供開始時）【PR2スコープ】
 - [ ] **6.4 LP + 料金ページ**（cat3 3-A = 既存フェーズ4 を包含。フェーズ4のタスクリストで管理）
 - [ ] **6.5 支払記録・未払い管理**（cat3 2-A、チケット/月契約と金銭の接続。Stripe Connect 決済代行 cat3 2-B はバックログ）

--- a/fit-connect-mobile/lib/features/auth/presentation/screens/profile_setup_screen.dart
+++ b/fit-connect-mobile/lib/features/auth/presentation/screens/profile_setup_screen.dart
@@ -118,9 +118,13 @@ class _ProfileSetupScreenState extends ConsumerState<ProfileSetupScreen> {
       registrationNotifier.setRegistrationComplete(true);
     } catch (e) {
       if (mounted) {
+        // 顧客数上限（CLIENT_LIMIT_REACHED）はユーザー向け文言をそのまま表示。他は既存挙動
+        final message = e is ClientLimitReachedException
+            ? ClientLimitReachedException.userMessage
+            : 'エラー: ${e.toString()}';
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('エラー: ${e.toString()}'),
+            content: Text(message),
             backgroundColor: AppColors.rose800,
           ),
         );

--- a/fit-connect-mobile/lib/features/auth/providers/registration_provider.dart
+++ b/fit-connect-mobile/lib/features/auth/providers/registration_provider.dart
@@ -2,8 +2,19 @@ import 'dart:io';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:fit_connect_mobile/services/supabase_service.dart';
 import 'package:fit_connect_mobile/services/storage_service.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show PostgrestException;
 
 part 'registration_provider.g.dart';
+
+/// トレーナーの顧客数上限（DBトリガーが 'CLIENT_LIMIT_REACHED' で拒否）による登録失敗。
+/// 注意: モバイル内では購入・アップグレード・価格への誘導を行わない（Apple IAP 規約）。
+class ClientLimitReachedException implements Exception {
+  static const String userMessage =
+      'このトレーナーは現在新しいお客様の受け入れを停止しています。トレーナーにお問い合わせください。';
+
+  @override
+  String toString() => userMessage;
+}
 
 /// 登録時の状態を保持するクラス
 class RegistrationState {
@@ -162,15 +173,23 @@ class RegistrationNotifier extends _$RegistrationNotifier {
 
     // clientsテーブルにレコード作成（既存の場合は更新）
     final userEmail = SupabaseService.client.auth.currentUser?.email;
-    await SupabaseService.client.from('clients').upsert({
-      'client_id': userId,
-      'trainer_id': trainerId,
-      'name':
-          state.clientName?.isNotEmpty == true ? state.clientName : '新規クライアント',
-      'email': userEmail,
-      if (state.clientAge != null) 'age': state.clientAge,
-      if (state.clientGender != null) 'gender': state.clientGender,
-    }, onConflict: 'client_id');
+    try {
+      await SupabaseService.client.from('clients').upsert({
+        'client_id': userId,
+        'trainer_id': trainerId,
+        'name':
+            state.clientName?.isNotEmpty == true ? state.clientName : '新規クライアント',
+        'email': userEmail,
+        if (state.clientAge != null) 'age': state.clientAge,
+        if (state.clientGender != null) 'gender': state.clientGender,
+      }, onConflict: 'client_id');
+    } on PostgrestException catch (e) {
+      // 顧客数上限のDBトリガーによる拒否のみユーザー向けメッセージに変換。他は既存挙動のまま
+      if (e.message.contains('CLIENT_LIMIT_REACHED')) {
+        throw ClientLimitReachedException();
+      }
+      rethrow;
+    }
 
     // プロフィール画像をアップロード（選択されている場合）
     if (state.profileImageFile != null) {

--- a/fit-connect-mobile/lib/features/meal_records/data/meal_estimation_api.dart
+++ b/fit-connect-mobile/lib/features/meal_records/data/meal_estimation_api.dart
@@ -1,9 +1,23 @@
 // lib/features/meal_records/data/meal_estimation_api.dart
 import 'package:fit_connect_mobile/features/meal_records/models/meal_estimation_result.dart';
 import 'package:fit_connect_mobile/services/supabase_service.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:supabase_flutter/supabase_flutter.dart' show FunctionException;
 
-enum MealEstimationErrorCode { forbidden, rateLimit, invalidInput, estimationFailed, emptyResult, network }
+/// - [rateLimit]: 日次上限超過（429 'RATE_LIMIT'）。画像リクエストのみ拒否
+/// - [freeQuotaExceeded]: Freeプランの月次プール使い切り（429 'FREE_QUOTA_EXCEEDED'）。全ブロック
+/// - [monthlyQuotaExceeded]: 有料プランの顧客あたり月次上限超過（429 'MONTHLY_QUOTA_EXCEEDED'）。
+///   画像リクエストのみ拒否（テキスト推定は通る）
+enum MealEstimationErrorCode {
+  forbidden,
+  rateLimit,
+  freeQuotaExceeded,
+  monthlyQuotaExceeded,
+  invalidInput,
+  estimationFailed,
+  emptyResult,
+  network,
+}
 
 class MealEstimationException implements Exception {
   final MealEstimationErrorCode code;
@@ -48,23 +62,34 @@ class MealEstimationApi {
       final msg = (details is Map && details['message'] is String)
           ? details['message'] as String
           : (e.reasonPhrase ?? 'Unknown error');
-      switch (errCode) {
-        case 'FORBIDDEN':
-          throw MealEstimationException(MealEstimationErrorCode.forbidden, msg);
-        case 'RATE_LIMIT':
-          throw MealEstimationException(MealEstimationErrorCode.rateLimit, msg);
-        case 'INVALID_INPUT':
-          throw MealEstimationException(MealEstimationErrorCode.invalidInput, msg);
-        case 'EMPTY_RESULT':
-          throw MealEstimationException(MealEstimationErrorCode.emptyResult, msg);
-        case 'ESTIMATION_FAILED':
-        default:
-          throw MealEstimationException(MealEstimationErrorCode.estimationFailed, msg);
-      }
+      throw MealEstimationException(codeFromServerError(errCode), msg);
     } on MealEstimationException {
       rethrow;
     } catch (e) {
       throw MealEstimationException(MealEstimationErrorCode.network, e.toString());
+    }
+  }
+
+  /// Edge Function の {error: '...'} 文字列を [MealEstimationErrorCode] にマップする。
+  /// 未知のコード・欠落時は estimationFailed にフォールバック。
+  @visibleForTesting
+  static MealEstimationErrorCode codeFromServerError(String? errCode) {
+    switch (errCode) {
+      case 'FORBIDDEN':
+        return MealEstimationErrorCode.forbidden;
+      case 'RATE_LIMIT':
+        return MealEstimationErrorCode.rateLimit;
+      case 'FREE_QUOTA_EXCEEDED':
+        return MealEstimationErrorCode.freeQuotaExceeded;
+      case 'MONTHLY_QUOTA_EXCEEDED':
+        return MealEstimationErrorCode.monthlyQuotaExceeded;
+      case 'INVALID_INPUT':
+        return MealEstimationErrorCode.invalidInput;
+      case 'EMPTY_RESULT':
+        return MealEstimationErrorCode.emptyResult;
+      case 'ESTIMATION_FAILED':
+      default:
+        return MealEstimationErrorCode.estimationFailed;
     }
   }
 }

--- a/fit-connect-mobile/lib/features/messages/presentation/widgets/structured_tag_form.dart
+++ b/fit-connect-mobile/lib/features/messages/presentation/widgets/structured_tag_form.dart
@@ -533,7 +533,11 @@ class _MealTagFormState extends ConsumerState<MealTagForm> {
   String _humanError(MealEstimationException e) {
     switch (e.code) {
       case MealEstimationErrorCode.rateLimit:
-        return 'AI推定の上限に達しました。しばらくしてからお試しください';
+        return '本日のAI推定の上限に達しました。写真なしのテキスト推定は引き続き利用できます';
+      case MealEstimationErrorCode.monthlyQuotaExceeded:
+        return '今月のAI推定（写真）の上限に達しました。テキスト推定は引き続き利用できます';
+      case MealEstimationErrorCode.freeQuotaExceeded:
+        return '今月のAI利用枠を使い切りました。来月また利用できます';
       case MealEstimationErrorCode.network:
         return '通信エラーが発生しました';
       case MealEstimationErrorCode.forbidden:
@@ -619,7 +623,7 @@ class _MealTagFormState extends ConsumerState<MealTagForm> {
         ),
         const SizedBox(height: 12),
 
-        // 入力モード切替（Pro のみ表示）。free/未解決時は従来フォーム（cook 固定）。
+        // 入力モード切替（AIゲート有効時のみ表示）。未解決時は従来フォーム（cook 固定）。
         if (ref.watch(aiFeaturesEnabledProvider).maybeWhen(
               data: (enabled) => enabled,
               orElse: () => false,

--- a/fit-connect-mobile/lib/features/subscription/providers/ai_features_enabled_provider.dart
+++ b/fit-connect-mobile/lib/features/subscription/providers/ai_features_enabled_provider.dart
@@ -4,13 +4,15 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ai_features_enabled_provider.g.dart';
 
-/// 自身の担当トレーナーがAI機能を利用可能かどうか（実効プラン判定）。
-/// - subscription_plan が 'pro' または 'business' → 利用可
-/// - 'free' でも trial_ends_at が現在より未来（トライアル中・Pro相当） → 利用可
-/// - それ以外・取得失敗・未認証・未紐付け → false（保守的にAI非表示）
+/// 自身の担当トレーナーが解決できるかどうか（AI機能のUIゲート）。
+/// - 担当トレーナーが解決できれば true（Freeプランにも月次クォータ内でAIが
+///   開放されたため、プラン文字列による出し分けは行わない）
+/// - 取得失敗・未認証・未紐付け → false（保守的にAI非表示）
+///
+/// クォータ制御はサーバー側（Edge Function の 429 応答）が実体。
+/// このUIゲートは将来のkill switch（AI機能の全停止）用に残している。
 ///
 /// 参照経路: auth.uid() → clients.client_id → clients.trainer_id
-///           → trainers.subscription_plan / trainers.trial_ends_at
 // TODO(stage 2): subscribe to auth.onAuthStateChange to invalidate on sign-in/out, and
 //                handle subscription_plan changes (Stripe webhook) to flip the gate live.
 @Riverpod(keepAlive: true)
@@ -34,26 +36,10 @@ Future<bool> aiFeaturesEnabled(AiFeaturesEnabledRef ref) async {
       return false;
     }
 
-    final trainerRow = await supabase
-        .from('trainers')
-        .select('subscription_plan, trial_ends_at')
-        .eq('id', trainerId)
-        .maybeSingle();
-    final plan = trainerRow?['subscription_plan'] as String?;
-    final trialEndsAtRaw = trainerRow?['trial_ends_at'] as String?;
-    final trialEndsAt =
-        trialEndsAtRaw != null ? DateTime.tryParse(trialEndsAtRaw) : null;
-    final isPaidPlan = plan == 'pro' || plan == 'business';
-    final isTrialActive =
-        trialEndsAt != null && trialEndsAt.isAfter(DateTime.now());
-    final enabled = isPaidPlan || isTrialActive;
     if (kDebugMode) {
-      debugPrint(
-        '[aiFeaturesEnabled] trainer=$trainerId plan=$plan '
-        'trialEndsAt=$trialEndsAtRaw → $enabled',
-      );
+      debugPrint('[aiFeaturesEnabled] trainer=$trainerId → true');
     }
-    return enabled;
+    return true;
   } catch (e, st) {
     if (kDebugMode) debugPrint('[aiFeaturesEnabled] error: $e\n$st');
     return false;

--- a/fit-connect-mobile/test/features/meal_records/data/meal_estimation_api_test.dart
+++ b/fit-connect-mobile/test/features/meal_records/data/meal_estimation_api_test.dart
@@ -1,0 +1,48 @@
+import 'package:fit_connect_mobile/features/meal_records/data/meal_estimation_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MealEstimationApi.codeFromServerError', () {
+    test('maps known server error strings to enum values', () {
+      expect(
+        MealEstimationApi.codeFromServerError('FORBIDDEN'),
+        MealEstimationErrorCode.forbidden,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError('RATE_LIMIT'),
+        MealEstimationErrorCode.rateLimit,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError('FREE_QUOTA_EXCEEDED'),
+        MealEstimationErrorCode.freeQuotaExceeded,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError('MONTHLY_QUOTA_EXCEEDED'),
+        MealEstimationErrorCode.monthlyQuotaExceeded,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError('INVALID_INPUT'),
+        MealEstimationErrorCode.invalidInput,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError('EMPTY_RESULT'),
+        MealEstimationErrorCode.emptyResult,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError('ESTIMATION_FAILED'),
+        MealEstimationErrorCode.estimationFailed,
+      );
+    });
+
+    test('falls back to estimationFailed for unknown or missing codes', () {
+      expect(
+        MealEstimationApi.codeFromServerError('SOMETHING_NEW'),
+        MealEstimationErrorCode.estimationFailed,
+      );
+      expect(
+        MealEstimationApi.codeFromServerError(null),
+        MealEstimationErrorCode.estimationFailed,
+      );
+    });
+  });
+}

--- a/fit-connect/src/components/clients/ClientInviteModal.tsx
+++ b/fit-connect/src/components/clients/ClientInviteModal.tsx
@@ -1,12 +1,16 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import { QRCodeCanvas } from 'qrcode.react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Copy, Download } from 'lucide-react'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { Copy, Download, AlertTriangle } from 'lucide-react'
+import { getClientCount } from '@/lib/supabase/getClientCount'
+import { PLANS, type PlanId } from '@/lib/billing/plans'
 
 type ClientInviteModalProps = {
   open: boolean
@@ -14,8 +18,60 @@ type ClientInviteModalProps = {
   trainerId: string
 }
 
+type ClientLimitInfo = {
+  count: number
+  maxClients: number
+  planLabel: string
+}
+
 export default function ClientInviteModal({ open, onOpenChange, trainerId }: ClientInviteModalProps) {
   const [copied, setCopied] = useState(false)
+  const [limitInfo, setLimitInfo] = useState<ClientLimitInfo | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    let cancelled = false
+
+    const fetchLimitInfo = async () => {
+      try {
+        const [count, res] = await Promise.all([
+          getClientCount(trainerId),
+          fetch('/api/billing/status'),
+        ])
+        if (!res.ok) {
+          throw new Error(`課金状態の取得に失敗しました (${res.status})`)
+        }
+        const data: { effectivePlan?: string } = await res.json()
+        const effectivePlan = data.effectivePlan
+        if (effectivePlan !== 'free' && effectivePlan !== 'pro' && effectivePlan !== 'business') {
+          throw new Error('不正なプラン値です')
+        }
+        const plan = PLANS[effectivePlan as PlanId]
+        if (!cancelled) {
+          setLimitInfo({
+            count,
+            maxClients: plan.maxClients,
+            planLabel: plan.label,
+          })
+        }
+      } catch (error) {
+        // 取得失敗時は既存表示のまま（DB側トリガーが最終防衛のため fail-open）
+        console.error('顧客数上限情報の取得エラー:', error)
+        if (!cancelled) {
+          setLimitInfo(null)
+        }
+      }
+    }
+
+    fetchLimitInfo()
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, trainerId])
+
+  const limitReached = limitInfo != null && limitInfo.count >= limitInfo.maxClients
 
   const handleCopy = async () => {
     try {
@@ -54,65 +110,94 @@ export default function ClientInviteModal({ open, onOpenChange, trainerId }: Cli
           <DialogTitle>クライアントを招待</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6">
-          {/* 説明テキスト */}
-          <p className="text-sm text-gray-600 text-center">
-            QRコードをスキャンするか、招待コードをアプリで入力してください
-          </p>
+        {limitReached ? (
+          <div className="space-y-6">
+            {/* 上限到達の警告（アップグレード誘導） */}
+            <Alert className="border-amber-200 bg-amber-50 text-amber-900 rounded-md [&>svg]:text-amber-600">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>顧客数が上限に達しています</AlertTitle>
+              <AlertDescription className="text-amber-800">
+                顧客数が上限（{limitInfo.maxClients}人）に達しています。
+                新しい顧客を招待するには、プランのアップグレードが必要です。
+              </AlertDescription>
+            </Alert>
 
-          {/* QRコード表示 */}
-          <div className="flex justify-center">
-            <div className="bg-white border rounded-lg p-4">
-              <QRCodeCanvas
-                id="invite-qr-code"
-                value={trainerId}
-                size={256}
-                level="H"
-                includeMargin={true}
-              />
-            </div>
+            <p className="text-sm text-gray-600 text-center">
+              顧客数: 現在{limitInfo.count}人 / 上限{limitInfo.maxClients}人（{limitInfo.planLabel}プラン）
+            </p>
+
+            <Button asChild className="w-full">
+              <Link href="/settings/billing">プランを確認する</Link>
+            </Button>
           </div>
+        ) : (
+          <div className="space-y-6">
+            {/* 説明テキスト */}
+            <p className="text-sm text-gray-600 text-center">
+              QRコードをスキャンするか、招待コードをアプリで入力してください
+            </p>
 
-          {/* 招待コード */}
-          <div className="space-y-2">
-            <Label htmlFor="invite-code">招待コード</Label>
-            <div className="flex gap-2">
-              <Input
-                id="invite-code"
-                type="text"
-                value={trainerId}
-                readOnly
-                className="font-mono text-sm"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                onClick={handleCopy}
-                className="shrink-0"
-              >
-                <Copy className="h-4 w-4" />
-              </Button>
+            {/* QRコード表示 */}
+            <div className="flex justify-center">
+              <div className="bg-white border rounded-lg p-4">
+                <QRCodeCanvas
+                  id="invite-qr-code"
+                  value={trainerId}
+                  size={256}
+                  level="H"
+                  includeMargin={true}
+                />
+              </div>
             </div>
-            {copied && (
-              <p className="text-sm text-emerald-600 flex items-center gap-1">
-                <span>✓</span>
-                <span>コピーしました</span>
+
+            {/* 招待コード */}
+            <div className="space-y-2">
+              <Label htmlFor="invite-code">招待コード</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="invite-code"
+                  type="text"
+                  value={trainerId}
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={handleCopy}
+                  className="shrink-0"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+              {copied && (
+                <p className="text-sm text-emerald-600 flex items-center gap-1">
+                  <span>✓</span>
+                  <span>コピーしました</span>
+                </p>
+              )}
+            </div>
+
+            {/* ダウンロードボタン */}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleDownloadQR}
+              className="w-full"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              QRコードをダウンロード
+            </Button>
+
+            {/* 顧客数の現在値 / 上限（控えめに表示） */}
+            {limitInfo && (
+              <p className="text-xs text-gray-500 text-center">
+                顧客数: 現在{limitInfo.count}人 / 上限{limitInfo.maxClients}人（{limitInfo.planLabel}プラン）
               </p>
             )}
           </div>
-
-          {/* ダウンロードボタン */}
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleDownloadQR}
-            className="w-full"
-          >
-            <Download className="h-4 w-4 mr-2" />
-            QRコードをダウンロード
-          </Button>
-        </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/supabase/functions/estimate-meal-nutrition/index.ts
+++ b/supabase/functions/estimate-meal-nutrition/index.ts
@@ -47,6 +47,16 @@ const SCREENSHOT_SYSTEM_PROMPT = `あなたは食事管理アプリの画面ス�
 
 const FUNCTION_NAME = 'estimate-meal-nutrition'
 
+// ---- レートリミット / クォータ定数 ----
+// 出典: docs/tasks/2026-07-11-pro-pricing-proposal.md §8 決定事項（2026-07-12 オーナー確定）
+// - Free: 月30回・トレーナー単位の共通プール（担当顧客全員の合計・全リクエスト種別）。使い切りで全ブロック
+// - 有料（pro/business/トライアル中）: 10回/顧客/日 + 100回/顧客/月。超過時はテキストのみ許可
+// - 全プラン共通: トレーナー単位 1000回/日 のバックストップ（従来からの既存値を維持）
+const FREE_TRAINER_MONTHLY_POOL = 30
+const PAID_CLIENT_DAILY_LIMIT = 10
+const PAID_CLIENT_MONTHLY_LIMIT = 100
+const TRAINER_DAILY_BACKSTOP = 1000
+
 async function callClaude(
   apiKey: string,
   mealType: string,
@@ -170,6 +180,19 @@ function validateEstimation(raw: any, trustTotals: boolean): { foods: any[]; tot
   return { foods, totals }
 }
 
+/**
+ * 「月」= JST（Asia/Tokyo, UTC+9・夏時間なし）の暦月。
+ * JST での月初 00:00 を UTC の ISO 文字列に変換して返し、created_at >= の比較に使う。
+ * 注意: UTC の月初とはずれる（例: JST 2026-07-01T00:00:00 は UTC では 2026-06-30T15:00:00Z）。
+ */
+function jstMonthStartIso(now: Date = new Date()): string {
+  const JST_OFFSET_MS = 9 * 60 * 60 * 1000
+  const jst = new Date(now.getTime() + JST_OFFSET_MS)
+  // シフト後の getUTC* が JST のローカル年月を表す
+  const monthStartUtcMs = Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), 1) - JST_OFFSET_MS
+  return new Date(monthStartUtcMs).toISOString()
+}
+
 function errorResponse(code: string, message: string, status: number) {
   return new Response(JSON.stringify({ error: code, message }), {
     status,
@@ -219,22 +242,25 @@ Deno.serve(async (req) => {
       return errorResponse('FORBIDDEN', 'Client not found', 403)
     }
 
-    // 3. subscription gate
-    // 実効プラン規則: pro / business は利用可。free でも trial_ends_at が未来なら
-    // トライアル中（Pro相当）として利用可。それ以外は不可。
+    // 3. トレーナー取得と実効プラン判定
+    // §8 決定（2026-07-12）: Free プランも月30回プールで AI を利用可のため、
+    // プランによる全面 403 は廃止。403 は trainers 行が見つからない/取得エラー時のみ。
+    // 実効プラン規則: pro / business、または trial_ends_at が未来（トライアル中 = Pro相当）
+    // なら有料ティア、それ以外は Free ティアとしてクォータ判定する。
     const { data: trainer, error: trainerErr } = await supabase
       .from('trainers')
       .select('id, subscription_plan, trial_ends_at')
       .eq('id', client.trainer_id)
       .maybeSingle()
-    const plan = trainer?.subscription_plan
+    if (trainerErr || !trainer) {
+      return errorResponse('FORBIDDEN', 'Trainer not found', 403)
+    }
+    const plan = trainer.subscription_plan
     const isPaidPlan = plan === 'pro' || plan === 'business'
     const isTrialActive =
-      typeof trainer?.trial_ends_at === 'string' &&
+      typeof trainer.trial_ends_at === 'string' &&
       new Date(trainer.trial_ends_at).getTime() > Date.now()
-    if (trainerErr || !trainer || !(isPaidPlan || isTrialActive)) {
-      return errorResponse('FORBIDDEN', 'AI features require pro plan', 403)
-    }
+    const isPaidTier = isPaidPlan || isTrialActive
 
     // 4. リクエスト body パース
     const body = await req.json().catch(() => null)
@@ -258,39 +284,86 @@ Deno.serve(async (req) => {
       return errorResponse('INVALID_INPUT', 'Empty content and no images', 400)
     }
 
-    // 5. Rate limit (Claude 呼び出し前にチェック、ログは Claude 呼び出し後に挿入)
-    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
-    const { count: clientCount, error: cErr } = await supabase
-      .from('ai_estimation_logs')
-      .select('*', { count: 'exact', head: true })
-      .eq('client_id', authUid)
-      .gte('created_at', since)
-    if (cErr) console.error('rate-limit (client) query error:', cErr)
-    if ((clientCount ?? 0) >= 50) {
-      await supabase.from('ai_estimation_logs').insert({
+    // 5. レートリミット / クォータ（Claude 呼び出し前にチェック）
+    // 出典: docs/tasks/2026-07-11-pro-pricing-proposal.md §8（2026-07-12 オーナー確定）
+    // - Free（非トライアル）: トレーナー単位・月30回の共通プール（担当顧客全員の合計・
+    //   全リクエスト種別を count）。使い切ったらテキストも含め全ブロック。日次判定はなし。
+    // - 有料ティア（pro/business/トライアル中）: 顧客単位 10回/日（24hローリング窓）
+    //   + 100回/月（JST暦月）。超過時はテキストのみ許可 = 画像付きリクエストのみ 429 を返す。
+    // - 全プラン共通: トレーナー単位 1000回/日 のバックストップ（既存挙動を維持）。
+    // count はいずれも従来同様「全 status の試行」を対象とする。
+    const hasImages = imageUrls.length > 0
+    const logQuotaError = (errorCode: string) =>
+      supabase.from('ai_estimation_logs').insert({
         client_id: authUid,
         trainer_id: client.trainer_id,
         function_name: FUNCTION_NAME,
         status: 'error',
-        error_code: 'RATE_LIMIT',
+        error_code: errorCode,
       })
-      return errorResponse('RATE_LIMIT', 'Per-client daily limit (50) exceeded', 429)
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+    if (isPaidTier) {
+      // 有料ティア: テキストのみのリクエストは顧客単位クォータの対象外（常に通す）ため、
+      // 画像付きのときだけ count クエリを発行する
+      if (hasImages) {
+        const { count: clientDaily, error: cdErr } = await supabase
+          .from('ai_estimation_logs')
+          .select('*', { count: 'exact', head: true })
+          .eq('client_id', authUid)
+          .gte('created_at', since)
+        if (cdErr) console.error('rate-limit (client daily) query error:', cdErr)
+        if ((clientDaily ?? 0) >= PAID_CLIENT_DAILY_LIMIT) {
+          await logQuotaError('RATE_LIMIT')
+          return errorResponse(
+            'RATE_LIMIT',
+            `Per-client daily limit (${PAID_CLIENT_DAILY_LIMIT}) exceeded`,
+            429,
+          )
+        }
+        const { count: clientMonthly, error: cmErr } = await supabase
+          .from('ai_estimation_logs')
+          .select('*', { count: 'exact', head: true })
+          .eq('client_id', authUid)
+          .gte('created_at', jstMonthStartIso())
+        if (cmErr) console.error('rate-limit (client monthly) query error:', cmErr)
+        if ((clientMonthly ?? 0) >= PAID_CLIENT_MONTHLY_LIMIT) {
+          await logQuotaError('MONTHLY_QUOTA_EXCEEDED')
+          return errorResponse(
+            'MONTHLY_QUOTA_EXCEEDED',
+            `Per-client monthly limit (${PAID_CLIENT_MONTHLY_LIMIT}) exceeded`,
+            429,
+          )
+        }
+      }
+    } else {
+      // Free ティア: トレーナー単位・月30回の共通プール（画像有無を問わず全ブロック対象）
+      const { count: trainerMonthly, error: fmErr } = await supabase
+        .from('ai_estimation_logs')
+        .select('*', { count: 'exact', head: true })
+        .eq('trainer_id', client.trainer_id)
+        .gte('created_at', jstMonthStartIso())
+      if (fmErr) console.error('rate-limit (free monthly pool) query error:', fmErr)
+      if ((trainerMonthly ?? 0) >= FREE_TRAINER_MONTHLY_POOL) {
+        await logQuotaError('FREE_QUOTA_EXCEEDED')
+        return errorResponse('FREE_QUOTA_EXCEEDED', '今月のAI利用枠を使い切りました', 429)
+      }
     }
+
+    // 全プラン共通バックストップ: トレーナー単位 1000回/日（既存エラー形式のまま）
     const { count: trainerCount, error: tErr } = await supabase
       .from('ai_estimation_logs')
       .select('*', { count: 'exact', head: true })
       .eq('trainer_id', client.trainer_id)
       .gte('created_at', since)
     if (tErr) console.error('rate-limit (trainer) query error:', tErr)
-    if ((trainerCount ?? 0) >= 1000) {
-      await supabase.from('ai_estimation_logs').insert({
-        client_id: authUid,
-        trainer_id: client.trainer_id,
-        function_name: FUNCTION_NAME,
-        status: 'error',
-        error_code: 'RATE_LIMIT',
-      })
-      return errorResponse('RATE_LIMIT', 'Per-trainer daily limit (1000) exceeded', 429)
+    if ((trainerCount ?? 0) >= TRAINER_DAILY_BACKSTOP) {
+      await logQuotaError('RATE_LIMIT')
+      return errorResponse(
+        'RATE_LIMIT',
+        `Per-trainer daily limit (${TRAINER_DAILY_BACKSTOP}) exceeded`,
+        429,
+      )
     }
 
     // 6. Claude 呼び出し

--- a/supabase/migrations/20260712100000_enforce_client_limit.sql
+++ b/supabase/migrations/20260712100000_enforce_client_limit.sql
@@ -1,0 +1,122 @@
+-- Migration: enforce_client_limit
+-- 目的: プランごとの顧客数上限を DB トリガーで強制する。
+--
+-- 仕様出典: docs/tasks/2026-07-11-pro-pricing-proposal.md §8（2026-07-12 オーナー確定）
+--   - 顧客数上限: Free=3人 / Pro=10人 / Business=30人
+--   - 実効プラン = subscription_plan != 'free' ? subscription_plan
+--                : (trial_ends_at > now() ? 'pro'(14日トライアル中) : 'free')
+--     （20260712000000_add_billing_foundation.sql §2 のアプリ側計算式と同一）
+--   - 超過時の挙動: 新規追加のブロックのみ。既存顧客が上限を超過していても削除・制限はしない
+--     （本トリガーは INSERT / trainer_id 変更 UPDATE の新規行にのみ作用し、既存行には触らない）
+--
+-- なぜ DB トリガーか:
+--   clients は Mobile 端末が RLS 経由で直接 INSERT / UPDATE する
+--   （registration_provider の upsert、onConflict: client_id。
+--     clients_update_own により本人が trainer_id を書き換え可能 = トレーナー乗り換え）。
+--   Web UI / API Route だけのゲートでは PostgREST 直叩きで迂回されるため、DB 側で強制する。
+--
+-- 既知の限界（許容済み）:
+--   同一トレーナーへの同時 INSERT が競合すると、双方の count(*) が上限未満を観測し、
+--   上限を僅かに超えて確定するレースが存在する（READ COMMITTED のスナップショット特性）。
+--   advisory lock（pg_advisory_xact_lock(trainer_id)）で直列化すれば防げるが、
+--   顧客登録は QR 連携由来の低頻度操作であり、超過しても高々同時実行数分に留まるため
+--   今回は導入しない。厳密化が必要になった時点で advisory lock を追加すること。
+
+-- ============================================================
+-- 1. トリガー関数 enforce_client_limit()
+-- ============================================================
+-- SECURITY DEFINER の理由:
+--   実行者は Mobile のクライアント本人（authenticated）だが、clients の SELECT ポリシーは
+--   「トレーナー本人の顧客のみ」等に絞られており、本人ロールのままでは
+--   移籍先トレーナー配下の顧客数を count できない。定義者（postgres = テーブルオーナー）
+--   権限で RLS を跨いで正確に数えるために必要。
+--   search_path 固定（public, pg_temp）で search_path ハイジャックを防ぐ。
+
+CREATE OR REPLACE FUNCTION public.enforce_client_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_plan           text;
+  v_trial_ends_at  timestamptz;
+  v_effective_plan text;
+  v_limit          integer;
+  v_current_count  bigint;
+BEGIN
+  -- trainer_id 未設定は対象外（現行スキーマは NOT NULL だが防御的に許可）
+  IF NEW.trainer_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE で trainer_id が変わらない場合は許可（乗り換えではない。
+  -- registration_provider の upsert が既存行に当たるケースもここで素通しになる）
+  IF TG_OP = 'UPDATE' AND OLD.trainer_id IS NOT DISTINCT FROM NEW.trainer_id THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT t.subscription_plan, t.trial_ends_at
+    INTO v_plan, v_trial_ends_at
+    FROM public.trainers t
+   WHERE t.id = NEW.trainer_id;
+
+  -- trainers 行が無ければ許可（存在しない trainer_id は clients_trainer_id_fkey が拒否する）
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  -- 実効プラン（20260712000000 §2 の計算式と同一）
+  IF COALESCE(v_plan, 'free') <> 'free' THEN
+    v_effective_plan := v_plan;
+  ELSIF v_trial_ends_at IS NOT NULL AND v_trial_ends_at > now() THEN
+    v_effective_plan := 'pro'; -- 14日 Pro トライアル中
+  ELSE
+    v_effective_plan := 'free';
+  END IF;
+
+  v_limit := CASE v_effective_plan
+    WHEN 'business' THEN 30
+    WHEN 'pro'      THEN 10
+    ELSE 3 -- free
+  END;
+
+  -- 自分自身（upsert / 乗り換え元の自行）を除いた現在の顧客数
+  SELECT count(*)
+    INTO v_current_count
+    FROM public.clients c
+   WHERE c.trainer_id = NEW.trainer_id
+     AND c.client_id <> NEW.client_id;
+
+  IF v_current_count >= v_limit THEN
+    -- メッセージ文字列 'CLIENT_LIMIT_REACHED' は固定。
+    -- クライアント側（Web/Mobile）はこの文字列でエラーマッチする。変更禁止。
+    RAISE EXCEPTION 'CLIENT_LIMIT_REACHED'
+      USING ERRCODE = 'P0001',
+            DETAIL  = format(
+              'trainer_id=%s plan=%s limit=%s current=%s',
+              NEW.trainer_id, v_effective_plan, v_limit, v_current_count
+            ),
+            HINT    = 'このトレーナーの顧客数がプラン上限に達しています。プランをアップグレードしてください。';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enforce_client_limit() IS
+  'プラン別顧客数上限（free=3/pro=10/business=30、トライアル中はpro扱い）を BEFORE トリガーで強制する。上限到達時は CLIENT_LIMIT_REACHED（P0001）。仕様: docs/tasks/2026-07-11-pro-pricing-proposal.md §8';
+
+-- ============================================================
+-- 2. トリガー enforce_client_limit_trigger
+-- ============================================================
+-- clients の既存トリガーは無し（2026-07-12 時点の migrations 全数確認）。
+-- UPDATE OF trainer_id: trainer_id が SET 句に含まれる UPDATE のみ発火。
+--   値が実際には変わらないケースは関数冒頭の IS NOT DISTINCT FROM ガードで素通しする。
+
+DROP TRIGGER IF EXISTS enforce_client_limit_trigger ON public.clients;
+
+CREATE TRIGGER enforce_client_limit_trigger
+  BEFORE INSERT OR UPDATE OF trainer_id ON public.clients
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_client_limit();


### PR DESCRIPTION
## 概要

フェーズ6.3 PR2: **プラン上限と AI クォータの enforcement**。PR #70（課金コア）で決めたプラン体系に、実際の制限を効かせます。

## 変更内容

### 顧客数上限（DBトリガー `enforce_client_limit`）
- free=3人 / pro=10人 / business=30人（トライアル中は pro 扱い）
- clients は **Mobile 端末が RLS 経由で直接 INSERT/UPDATE** するため、DB トリガーで強制（Web UI だけでは迂回可能）。トレーナー乗り換え（trainer_id の UPDATE）もチェック
- 超過時は新規追加のみブロック（既存顧客は不問 = オーナー決定どおり）。エラーメッセージ `CLIENT_LIMIT_REACHED` 固定でクライアント側がマッチ

### AI クォータ（`estimate-meal-nutrition` 書き換え）

| プラン | ルール | 超過時 |
| --- | --- | --- |
| 有料（pro/business/トライアル） | 10回/顧客/日 + 100回/顧客/月（JST暦月） | **写真のみ拒否・テキスト推定は継続許可** |
| Free（非トライアル） | **月30回・トレーナー単位プール（新規開放）** | 全停止（来月復活） |
| 全プラン | トレーナー1000回/日バックストップ | 従来どおり |

- Free プランは従来 403 で全面拒否 → **月30回のお試しが使えるように**（オーナー決定 §8）
- 新エラーコード: `FREE_QUOTA_EXCEEDED` / `MONTHLY_QUOTA_EXCEEDED`（レスポンス形式は既存踏襲）

### Mobile
- AI ボタンのプランゲートを開放（Free もお試し可になったため。実制御はサーバー 429）
- クォータ超過の文言を状況別に（「テキスト推定は引き続き利用できます」等）。既存の「AIなしで送信」フォールバック維持
- 顧客登録が上限で弾かれた場合: 「このトレーナーは現在新しいお客様の受け入れを停止しています。トレーナーにお問い合わせください。」
- **購入・価格への言及は一切追加していません**（Apple IAP 規約）

### Web
- 招待モーダルに「顧客数: 現在◯人 / 上限◯人（◯◯プラン）」表示。上限到達時は QR を隠して警告 + 「プランを確認する」→ /settings/billing

## 検証

| 項目 | 結果 |
| --- | --- |
| ローカル db reset + psql 10ケース | ✅ 3/10/30境界・トライアル切替・乗り換えUPDATE拒否・同値UPDATE素通し・service_roleでも発火 |
| `deno check` + JST月境界の実行テスト | ✅（月初・月末・年またぎ） |
| `tsc` / vitest / `next build` | ✅ 50テスト |
| `flutter analyze` / `flutter test` | ✅ 61件（エラーコードマッピングの新規テスト2件） |
| ブラウザQA | ✅ 実データ（顧客12人・Pro上限10人）で上限到達UIを確認（下記） |

上限到達時の招待モーダル:
- QR/招待コード非表示 + amber警告「顧客数が上限（10人）に達しています…」+「顧客数: 現在12人 / 上限10人（Proプラン）」+ プラン確認ボタン

## マージ後の作業（私がやります）

1. `supabase db push`（トリガー適用）
2. `supabase functions deploy estimate-meal-nutrition`（新クォータ反映）

## 留意点

- あなたのアカウントは顧客12人 > Pro上限10人の超過状態ですが、既存分はそのまま使えます（新規追加のみブロック）
- 同時INSERTのレースで上限を僅かに超え得る点は既知の限界としてmigrationコメントに明記（advisory lock不採用）
- 特商法ページの価格記入は本番リリース時タスクとして残置

🤖 Generated with [Claude Code](https://claude.com/claude-code)
